### PR TITLE
bug: only create access token for the repository needed

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -13,7 +13,7 @@
             <env name="ENTRA_ID_TENANT_ID" value="c6ea0b0b-e867-46d4-a70b-4c05887e7f6f" />
             <env name="FILENAME_PREFIX" value="ros"/>
             <env name="FILENAME_POSTFIX" value="ros"/>
-            <env name="JSON_SCHEMA_BASE_URL" value="https://bekk.github.io/kv-ros-backend"/>
+            <env name="JSON_SCHEMA_BASE_URL" value="https://kartverket.github.io/backstage-plugin-risk-scorecard-backend"/>
         </envs>
         <module name="kv-ros-backend.main"/>
         <option name="SPRING_BOOT_MAIN_CLASS" value="no.kvros.KvRosApplication"/>

--- a/src/main/kotlin/no/kvros/infra/connector/JSONSchemaConnector.kt
+++ b/src/main/kotlin/no/kvros/infra/connector/JSONSchemaConnector.kt
@@ -7,11 +7,10 @@ import org.springframework.stereotype.Component
 class JSONSchemaConnector(
     @Value("\${json-schema-base-url}") baseUrl: String,
 ) : WebClientConnector(baseUrl) {
-
     fun fetchJSONSchema(schemaVersion: String): String? {
         return try {
             webClient.get()
-                .uri("/ros_schema_no_v3_2.json")
+                .uri("/ros_schema_no_v$schemaVersion.json")
                 .header("Accept", "application/vnd.github.json")
                 .retrieve()
                 .bodyToMono(String::class.java)


### PR DESCRIPTION
- Github access token should only have access to the specific repository needed
- Formatting sucks <|:^) The only line changed is in `GithubAppConnector::getGithubAppAccessToken`: `.bodyValue(GithubHelper.bodyToCreateAccessTokenForRepository(repositoryName).toContentBody())`
- `JSON_SCHEMA_BASE_URL` should contain the url for this repo