### PR TITLE
Add global exception handler

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -7,7 +7,7 @@
       <env name="GITHUB_PRIVATE_KEY_SECRET_NAME" value="projects/984647225311/secrets/ros-plugin-github-private-key/versions/latest" />
       <env name="RISC_FOLDER_PATH" value=".security/risc" />
       <env name="SOPS_AGE_KEY" value="AGE-SECRET-KEY-1X5DH3RVJ83CK3TJNGGC5QA277NRC9JDK2W5DUG8DY5P05CVL88WS8FT049" />
-      <env name="ISSUER_URI" value="http://localhost:7007/api/auth" />
+      <env name="ISSUER_URI" value="https://sandbox.kartverket.dev/api/auth" />
       <env name="FILENAME_PREFIX" value="risc" />
       <env name="FILENAME_POSTFIX" value="risc" />
       <env name="JSON_SCHEMA_PATH" value="/kartverket/backstage-plugin-risk-scorecard-backend/contents/docs"/>

--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -7,7 +7,7 @@
       <env name="GITHUB_PRIVATE_KEY_SECRET_NAME" value="projects/984647225311/secrets/ros-plugin-github-private-key/versions/latest" />
       <env name="RISC_FOLDER_PATH" value=".security/risc" />
       <env name="SOPS_AGE_KEY" value="AGE-SECRET-KEY-1X5DH3RVJ83CK3TJNGGC5QA277NRC9JDK2W5DUG8DY5P05CVL88WS8FT049" />
-      <env name="ISSUER_URI" value="https://sandbox.kartverket.dev/api/auth" />
+      <env name="ISSUER_URI" value="http://localhost:7007/api/auth" />
       <env name="FILENAME_PREFIX" value="risc" />
       <env name="FILENAME_POSTFIX" value="risc" />
       <env name="JSON_SCHEMA_PATH" value="/kartverket/backstage-plugin-risk-scorecard-backend/contents/docs"/>

--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,86 @@
+package no.risc.exception
+
+import no.risc.exception.exceptions.*
+import no.risc.risc.ProcessRiScResultDTO
+import no.risc.risc.ProcessingStatus
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ControllerAdvice
+internal class GlobalExceptionHandler {
+    private val logger: Logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    @ExceptionHandler(JSONSchemaFetchException::class)
+    fun handleJSONSchemaFetchException(ex: JSONSchemaFetchException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            ex.riScId,
+            ProcessingStatus.ErrorWhenUpdatingRiSc,
+            "Could not fetch JSON schema",
+        )
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    @ExceptionHandler(RiScNotValidException::class)
+    fun handleRiScNotValidException(ex: RiScNotValidException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            ex.riScId,
+            ProcessingStatus.ErrorWhenUpdatingRiSc,
+            ex.validationError,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    @ExceptionHandler(SopsConfigFetchException::class)
+    fun handleSopsConfigFetchException(ex: SopsConfigFetchException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            ex.riScId,
+            ProcessingStatus.ErrorWhenUpdatingRiSc,
+            "Could not fetch SOPS config",
+        )
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    @ExceptionHandler(SopsEncryptionException::class)
+    fun handleSopsEncryptionException(ex: SopsEncryptionException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            ex.riScId,
+            ProcessingStatus.ErrorWhenUpdatingRiSc,
+            "Could not encrypt RiSc",
+        )
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    @ExceptionHandler(UpdatingRiScException::class)
+    fun handleUpdatingRiScException(ex: UpdatingRiScException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            ex.riScId,
+            ProcessingStatus.ErrorWhenUpdatingRiSc,
+            ex.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ResponseBody
+    @ExceptionHandler(InvalidAccessTokensException::class)
+    fun handleInvalidAccessTokensException(ex: InvalidAccessTokensException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO.INVALID_ACCESS_TOKENS
+    }
+
+}

--- a/src/main/kotlin/no/risc/exception/exceptions/InvalidAccessTokensException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/InvalidAccessTokensException.kt
@@ -1,0 +1,5 @@
+package no.risc.exception.exceptions
+
+data class InvalidAccessTokensException(
+    override val message: String?
+) : Exception()

--- a/src/main/kotlin/no/risc/exception/exceptions/JSONSchemaFetchException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/JSONSchemaFetchException.kt
@@ -1,0 +1,8 @@
+package no.risc.exception.exceptions
+
+import java.lang.Exception
+
+data class JSONSchemaFetchException(
+    override val message: String,
+    val riScId: String
+) : Exception()

--- a/src/main/kotlin/no/risc/exception/exceptions/RiScNotValidException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/RiScNotValidException.kt
@@ -1,0 +1,7 @@
+package no.risc.exception.exceptions
+
+data class RiScNotValidException(
+    override val message: String,
+    val riScId: String,
+    val validationError: String,
+) : Exception()

--- a/src/main/kotlin/no/risc/exception/exceptions/SopsConfigFetchException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/SopsConfigFetchException.kt
@@ -1,0 +1,6 @@
+package no.risc.exception.exceptions
+
+data class SopsConfigFetchException(
+    override val message: String,
+    val riScId: String,
+) : Exception()

--- a/src/main/kotlin/no/risc/exception/exceptions/SopsEncryptionException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/SopsEncryptionException.kt
@@ -1,0 +1,6 @@
+package no.risc.exception.exceptions
+
+data class SopsEncryptionException(
+    override val message: String,
+    val riScId: String,
+) : Exception()

--- a/src/main/kotlin/no/risc/exception/exceptions/UpdatingRiScException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/UpdatingRiScException.kt
@@ -1,0 +1,6 @@
+package no.risc.exception.exceptions
+
+data class UpdatingRiScException (
+    override val message: String,
+    val riScId: String,
+) : Exception()

--- a/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
+++ b/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
@@ -10,3 +10,7 @@ data class AccessTokens(
 }
 
 data class GCPAccessToken(val value: String)
+
+fun GCPAccessToken.sensor() = GCPAccessToken(
+    value = value.slice(IntRange(0, 3))+"****",
+)


### PR DESCRIPTION
Ønsker å logge hva som går galt når backend må returnere 500. Introduserer derfor `GlobalExceptionHandler`. I `exception.exceptions` kan vi introdusere egne exceptions som vi kan kaste, og i `GlobalExceptionHandler` kan vi bestemme hva som skal skje når vi kaster exceptions. Per nå har jeg endret til at `RiScService.updateOrCreateRiSc` kaster exceptions for at `GlobalExceptionHandler` skal logge disse og returnere 500 responsen med samme body som tidligere.