### PR TITLE
Remove atomic ref on Github App token

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -7,7 +7,7 @@
       <env name="GITHUB_PRIVATE_KEY_SECRET_NAME" value="projects/984647225311/secrets/ros-plugin-github-private-key/versions/latest" />
       <env name="RISC_FOLDER_PATH" value=".security/risc" />
       <env name="SOPS_AGE_KEY" value="AGE-SECRET-KEY-1X5DH3RVJ83CK3TJNGGC5QA277NRC9JDK2W5DUG8DY5P05CVL88WS8FT049" />
-      <env name="ISSUER_URI" value="http://localhost:7007/api/auth" />
+      <env name="ISSUER_URI" value="https://sandbox.kartverket.dev/api/auth" />
       <env name="FILENAME_PREFIX" value="risc" />
       <env name="FILENAME_POSTFIX" value="risc" />
       <env name="JSON_SCHEMA_PATH" value="/kartverket/backstage-plugin-risk-scorecard-backend/contents/docs"/>

--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -7,7 +7,7 @@
       <env name="GITHUB_PRIVATE_KEY_SECRET_NAME" value="projects/984647225311/secrets/ros-plugin-github-private-key/versions/latest" />
       <env name="RISC_FOLDER_PATH" value=".security/risc" />
       <env name="SOPS_AGE_KEY" value="AGE-SECRET-KEY-1X5DH3RVJ83CK3TJNGGC5QA277NRC9JDK2W5DUG8DY5P05CVL88WS8FT049" />
-      <env name="ISSUER_URI" value="https://sandbox.kartverket.dev/api/auth" />
+      <env name="ISSUER_URI" value="http://localhost:7007/api/auth" />
       <env name="FILENAME_PREFIX" value="risc" />
       <env name="FILENAME_POSTFIX" value="risc" />
       <env name="JSON_SCHEMA_PATH" value="/kartverket/backstage-plugin-risk-scorecard-backend/contents/docs"/>

--- a/src/main/kotlin/no/risc/github/GithubAppConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubAppConnector.kt
@@ -20,7 +20,6 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.*
-import java.util.concurrent.atomic.AtomicReference
 
 class GithubAccessToken(
     val value: String,
@@ -37,22 +36,15 @@ class GithubAppConnector(
     private val logger: Logger = getLogger(GithubAppConnector::class.java)
     private val gcpClientConnector = GcpClientConnector()
 
-    private val installationTokenBody: AtomicReference<GithubAccessTokenBody> = AtomicReference()
-
     internal fun getAccessTokenFromApp(repositoryName: String): GithubAccessToken {
-        if (installationTokenBody.get() == null || installationTokenBody.get().isExpired()) {
-            installationTokenBody.set(
-                getGithubAppAccessToken(
-                    jwt = generateJWT(
-                        gcpClientConnector.getSecretValue(privateKeySecretName)
-                            ?: throw Exception("Kunne ikke hente github app private key")
-                    ),
-                    repositoryName = repositoryName
-                )
-            )
-        }
         return GithubAccessToken(
-            installationTokenBody.get().token
+            getGithubAppAccessToken(
+                jwt = generateJWT(
+                    gcpClientConnector.getSecretValue(privateKeySecretName)
+                        ?: throw Exception("Kunne ikke hente github app private key")
+                ),
+                repositoryName = repositoryName
+            ).token
         )
     }
 

--- a/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
+++ b/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
@@ -5,9 +5,7 @@ import no.risc.github.GithubAccessToken
 data class AccessTokens(
     val githubAccessToken: GithubAccessToken,
     val gcpAccessToken: GCPAccessToken,
-) {
-    fun isValid(): Boolean = gcpAccessToken.value.isNotBlank() && githubAccessToken.value.isNotBlank()
-}
+)
 
 data class GCPAccessToken(val value: String)
 

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -32,12 +32,7 @@ class RiScController(
         @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
-    ): ResponseEntity<List<RiScContentResultDTO>> {
-        val result =
-            riScService.fetchAllRiScs(repositoryOwner, repositoryName, getAccessTokens(gcpAccessToken, repositoryName))
-
-        return ResponseEntity.ok().body(result)
-    }
+    ): List<RiScContentResultDTO> = riScService.fetchAllRiScs(repositoryOwner, repositoryName, getAccessTokens(gcpAccessToken, repositoryName))
 
     @PostMapping("/{repositoryOwner}/{repositoryName}", produces = ["text/plain"])
     fun createNewRiSc(


### PR DESCRIPTION
Introduserte `AtomicReference` på Github App Installation tokenet for å redusere unødvendige uthentinger av token. Dette blir dessverre krøll på SKIP når tjenesten replikeres på flere poder.