### PR TITLE
Optimalize fetch all riscs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation("org.springframework.security:spring-security-oauth2-resource-server")
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.1")
 
     implementation("io.netty:netty-all:4.1.100.Final")
 

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -1,5 +1,6 @@
 package no.risc.github
 
+import kotlinx.coroutines.*
 import net.pwall.log.getLogger
 import no.risc.exception.exceptions.SopsConfigFetchException
 import no.risc.github.models.FileContentDTO
@@ -22,6 +23,8 @@ import reactor.core.publisher.Mono
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.awaitBodyOrNull
 
 data class GithubContentResponse(
     val data: String?,
@@ -58,7 +61,7 @@ data class GithubWriteToFilePayload(
         }
 }
 
-data class Author(val name: String, val email: String, val date: Date) {
+data class Author(val name: String?, val email: String?, val date: Date) {
     fun formattedDate(): String = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(date)
 }
 
@@ -97,23 +100,27 @@ class GithubConnector(
             )
         }
 
-    fun fetchAllRiScIdentifiersInRepository(
+    suspend fun fetchAllRiScIdentifiersInRepository(
         owner: String,
         repository: String,
         accessToken: String,
-    ): GithubRiScIdentifiersResponse {
-        val draftRiScs = fetchRiScIdentifiersDrafted(owner, repository, accessToken)
-        val publishedRiScs = fetchPublishedRiScIdentifiers(owner, repository, accessToken)
-        val riScsSentForApproval = fetchRiScIdentifiersSentForApproval(owner, repository, accessToken)
+    ): GithubRiScIdentifiersResponse = coroutineScope {
+        val draftRiScsDeferred = async { fetchRiScIdentifiersDrafted(owner, repository, accessToken) }
+        val publishedRiScsDeferred = async { fetchPublishedRiScIdentifiers(owner, repository, accessToken) }
+        val riScsSentForApprovalDeferred = async { fetchRiScIdentifiersSentForApproval(owner, repository, accessToken) }
 
-        return GithubRiScIdentifiersResponse(
+        val draftRiScs = draftRiScsDeferred.await()
+        val publishedRiScs = publishedRiScsDeferred.await()
+        val riScsSentForApproval = riScsSentForApprovalDeferred.await()
+
+         GithubRiScIdentifiersResponse(
             status = GithubStatus.Success,
             ids =
-                combinePublishedDraftAndSentForApproval(
-                    draftRiScList = draftRiScs,
-                    sentForApprovalList = riScsSentForApproval,
-                    publishedRiScList = publishedRiScs,
-                ),
+            combinePublishedDraftAndSentForApproval(
+                draftRiScList = draftRiScs,
+                sentForApprovalList = riScsSentForApproval,
+                publishedRiScList = publishedRiScs,
+            ),
         )
     }
 
@@ -131,7 +138,7 @@ class GithubConnector(
         return sentForApprovalList + publishedRiScIdentifiersNotInDraftList + draftRiScIdentifiersNotInSentForApprovalsList
     }
 
-    fun fetchPublishedRiSc(
+    suspend fun fetchPublishedRiSc(
         owner: String,
         repository: String,
         id: String,
@@ -139,7 +146,7 @@ class GithubConnector(
     ): GithubContentResponse =
         try {
             val fileContent =
-                getGithubResponse(githubHelper.uriToFindRiSc(owner, repository, id), accessToken).decodedFileContent()
+                getGithubResponseSuspend(githubHelper.uriToFindRiSc(owner, repository, id), accessToken).decodedFileContentSuspend()
             when (fileContent) {
                 null -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
                 else -> GithubContentResponse(fileContent, GithubStatus.Success)
@@ -168,8 +175,7 @@ class GithubConnector(
         } catch (e: Exception) {
             GithubContentResponse(null, mapWebClientExceptionToGithubStatus(e))
         }
-
-    fun fetchDraftedRiScContent(
+    suspend fun fetchDraftedRiScContent(
         owner: String,
         repository: String,
         id: String,
@@ -177,8 +183,8 @@ class GithubConnector(
     ): GithubContentResponse =
         try {
             val fileContent =
-                getGithubResponse(githubHelper.uriToFindRiScOnDraftBranch(owner, repository, id), accessToken)
-                    .decodedFileContent()
+                getGithubResponseSuspend(githubHelper.uriToFindRiScOnDraftBranch(owner, repository, id), accessToken)
+                    .decodedFileContentSuspend()
 
             when (fileContent) {
                 null -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
@@ -188,40 +194,48 @@ class GithubConnector(
             GithubContentResponse(null, mapWebClientExceptionToGithubStatus(e))
         }
 
-    private fun fetchPublishedRiScIdentifiers(
+    private suspend fun fetchPublishedRiScIdentifiers(
         owner: String,
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
         try {
-            getGithubResponse(githubHelper.uriToFindRiScFiles(owner, repository), accessToken)
-                .riScIdentifiersPublished()
+            val response = getGithubResponseSuspend(
+                githubHelper.uriToFindRiScFiles(owner, repository),
+                accessToken
+            ).awaitBody<List<FileNameDTO>>()
+
+            response.riScIdentifiersPublished()
         } catch (e: Exception) {
             emptyList()
         }
 
-    private fun fetchRiScIdentifiersSentForApproval(
+    private suspend fun fetchRiScIdentifiersSentForApproval(
         owner: String,
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
         try {
-            getGithubResponse(githubHelper.uriToFetchAllPullRequests(owner, repository), accessToken)
-                .pullRequestResponseDTOs().riScIdentifiersSentForApproval()
+            val response = getGithubResponseSuspend(githubHelper.uriToFetchAllPullRequests(owner, repository), accessToken)
+                .awaitBody<List<GithubPullRequestObject>>()
+
+                response.riScIdentifiersSentForApproval()
         } catch (e: Exception) {
             emptyList()
         }
 
-    private fun fetchRiScIdentifiersDrafted(
+    private suspend fun fetchRiScIdentifiersDrafted(
         owner: String,
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
         try {
-            getGithubResponse(
+            val response = getGithubResponseSuspend(
                 githubHelper.uriToFindAllRiScBranches(owner, repository),
                 accessToken,
-            ).toReferenceObjects().riScIdentifiersDrafted()
+            ).awaitBody<List<GithubReferenceObjectDTO>>().map { it.toInternal() }
+
+                response.riScIdentifiersDrafted()
         } catch (e: Exception) {
             emptyList()
         }
@@ -261,15 +275,18 @@ class GithubConnector(
             ),
         ).bodyToMono<String>().block()
 
-        val prExists = pullRequestForRiScExists(owner, repository, riScId, accessToken)
-        if (!requiresNewApproval and !prExists) {
-            createPullRequestForRiSc(owner, repository, riScId, requiresNewApproval, accessTokens, userInfo)
-        }
-        if (requiresNewApproval and prExists) {
-            closePullRequestForRiSc(owner, repository, riScId, accessToken)
-        }
 
-        return requiresNewApproval and prExists
+            val prExists =  runBlocking {
+             val prExists = pullRequestForRiScExists(owner, repository, riScId, accessToken)
+            if (!requiresNewApproval && !prExists) {
+                createPullRequestForRiSc(owner, repository, riScId, requiresNewApproval, accessTokens, userInfo)
+            }
+            if (requiresNewApproval && prExists) {
+                closePullRequestForRiSc(owner, repository, riScId, accessToken)
+            }
+            prExists
+        }
+        return requiresNewApproval && prExists
     }
 
     private fun closePullRequestForRiSc(
@@ -310,7 +327,7 @@ class GithubConnector(
         accessToken: String,
     ): Boolean = fetchBranchForRiSc(owner, repository, riScId, accessToken).isNotEmpty()
 
-    private fun pullRequestForRiScExists(
+   private suspend fun pullRequestForRiScExists(
         owner: String,
         repository: String,
         riScId: String,
@@ -432,6 +449,18 @@ class GithubConnector(
         .body(Mono.just(writePayload.toContentBody()), String::class.java)
         .retrieve()
 
+
+    private suspend fun getGithubResponseSuspend(
+        uri: String,
+        accessToken: String,
+    ): ResponseSpec =
+        webClient.get()
+            .uri(uri)
+            .header("Accept", "application/vnd.github.json")
+            .header("Authorization", "token $accessToken")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .retrieve()
+
     private fun getGithubResponse(
         uri: String,
         accessToken: String,
@@ -455,10 +484,9 @@ class GithubConnector(
 
     private fun ResponseSpec.pullRequestResponseDTO(): GithubPullRequestObject? = this.bodyToMono<GithubPullRequestObject>().block()
 
-    private fun ResponseSpec.riScIdentifiersPublished(): List<RiScIdentifier> =
-        this.bodyToMono<List<FileNameDTO>>().block()
-            ?.filter { it.value.endsWith(".$filenamePostfix.yaml") }
-            ?.map { RiScIdentifier(it.value.substringBefore(".$filenamePostfix"), RiScStatus.Published) } ?: emptyList()
+    private fun List<FileNameDTO>.riScIdentifiersPublished(): List<RiScIdentifier> =
+        this.filter { it.value.endsWith(".$filenamePostfix.yaml") }
+            .map { RiScIdentifier(it.value.substringBefore(".$filenamePostfix"), RiScStatus.Published) }
 
     private fun List<GithubPullRequestObject>.riScIdentifiersSentForApproval(): List<RiScIdentifier> =
         this.map { RiScIdentifier(it.head.ref.split("/").last(), RiScStatus.SentForApproval) }
@@ -470,6 +498,12 @@ class GithubConnector(
     private fun ResponseSpec.schemaFilenames(): List<FileNameDTO>? = this.bodyToMono<List<FileNameDTO>>().block()
 
     private fun ResponseSpec.decodedFileContent(): String? = this.bodyToMono<FileContentDTO>().block()?.value?.decodeBase64()
+
+    private suspend fun ResponseSpec.decodedFileContentSuspend(): String? {
+        val fileContentDTO: FileContentDTO? = this.awaitBodyOrNull()
+        return fileContentDTO?.value?.decodeBase64()
+    }
+
 
     private fun ResponseSpec.rawFileContent(): String? = this.bodyToMono<String>().block()
 

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -3,6 +3,7 @@ package no.risc.risc
 import no.risc.exception.exceptions.InvalidAccessTokensException
 import no.risc.github.GithubAccessToken
 import no.risc.github.GithubAppConnector
+import no.risc.github.GithubRiScIdentifiersResponse
 import no.risc.github.GithubStatus
 import no.risc.infra.connector.GoogleApiConnector
 import no.risc.infra.connector.models.AccessTokens
@@ -27,15 +28,22 @@ class RiScController(
     private val githubAppConnector: GithubAppConnector,
     private val googleApiConnector: GoogleApiConnector,
 ) {
+    @GetMapping("/{repositoryOwner}/{repositoryName}/filenames")
+    suspend fun getRiScNames(
+        @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
+        @PathVariable repositoryOwner: String,
+        @PathVariable repositoryName: String,
+    ): GithubRiScIdentifiersResponse = riScService.fetchAllRiScIds(repositoryOwner, repositoryName, getAccessTokens(gcpAccessToken, repositoryName))
+
     @GetMapping("/{repositoryOwner}/{repositoryName}/all")
-    fun getRiScFilenames(
+    suspend fun getAllRiScs(
         @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
     ): List<RiScContentResultDTO> = riScService.fetchAllRiScs(repositoryOwner, repositoryName, getAccessTokens(gcpAccessToken, repositoryName))
 
     @PostMapping("/{repositoryOwner}/{repositoryName}")
-    fun createNewRiSc(
+    suspend fun createNewRiSc(
         @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
@@ -48,7 +56,7 @@ class RiScController(
     )
 
     @PutMapping("/{repositoryOwner}/{repositoryName}/{id}", produces = ["application/json"])
-    fun editRiSc(
+    suspend fun editRiSc(
         @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
         @PathVariable repositoryOwner: String,
         @PathVariable id: String,

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -1,12 +1,10 @@
 package no.risc.risc
 
+import kotlinx.coroutines.Dispatchers
 import no.risc.encryption.SOPS
 import no.risc.encryption.SOPSDecryptionException
 import no.risc.exception.exceptions.*
-import no.risc.github.GithubConnector
-import no.risc.github.GithubContentResponse
-import no.risc.github.GithubPullRequestObject
-import no.risc.github.GithubStatus
+import no.risc.github.*
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.risc.models.RiScWrapperObject
@@ -15,6 +13,11 @@ import no.risc.validation.JSONValidator
 import org.apache.commons.lang3.RandomStringUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.slf4j.LoggerFactory
+import kotlin.time.measureTimedValue
 
 data class ProcessRiScResultDTO(
     val riScId: String,
@@ -104,25 +107,56 @@ class RiScService(
     private val githubConnector: GithubConnector,
     @Value("\${sops.ageKey}") val ageKey: String,
     @Value("\${filename.prefix}") val filenamePrefix: String,
-) {
-    fun fetchAllRiScs(
+) { private val logger = LoggerFactory.getLogger(RiScService::class.java)
+    suspend fun fetchAllRiScIds(
         owner: String,
         repository: String,
         accessTokens: AccessTokens,
-    ): List<RiScContentResultDTO> =
+    ): GithubRiScIdentifiersResponse =
         githubConnector.fetchAllRiScIdentifiersInRepository(
             owner,
             repository,
             accessTokens.githubAccessToken.value,
-        ).ids.map { id ->
-            val fetchRisc =
-                when (id.status) {
-                    RiScStatus.Published -> githubConnector::fetchPublishedRiSc
-                    RiScStatus.SentForApproval, RiScStatus.Draft -> githubConnector::fetchDraftedRiScContent
-                }
-            fetchRisc(owner, repository, id.id, accessTokens.githubAccessToken.value)
-                .responseToRiScResult(id.id, id.status, accessTokens.gcpAccessToken)
+        )
+
+    suspend fun fetchAllRiScs(
+        owner: String,
+        repository: String,
+        accessTokens: AccessTokens,
+    ): List<RiScContentResultDTO> = coroutineScope {
+        val msId = measureTimedValue {
+            githubConnector.fetchAllRiScIdentifiersInRepository(
+                owner,
+                repository,
+                accessTokens.githubAccessToken.value,
+            ).ids
         }
+        logger.info("Fetching risc ids took ${msId.duration}")
+
+        val msRiSc = measureTimedValue {
+            msId.value.map { id ->
+                async(Dispatchers.IO) {
+                    try {
+                        val fetchRisc = when (id.status) {
+                            RiScStatus.Published -> githubConnector::fetchPublishedRiSc
+                            RiScStatus.SentForApproval, RiScStatus.Draft -> githubConnector::fetchDraftedRiScContent
+                        }
+                        fetchRisc(owner, repository, id.id, accessTokens.githubAccessToken.value)
+                            .responseToRiScResult(id.id, id.status, accessTokens.gcpAccessToken)
+                    } catch (e: Exception) {
+                        RiScContentResultDTO(
+                            riScId = id.id,
+                            status = ContentStatus.Failure,
+                            riScStatus = id.status,
+                            riScContent = null
+                        )
+                    }
+                }
+            }.awaitAll()
+        }
+
+        logger.info("Fetching ${msId.value.count()} RiScs took ${msRiSc.duration}")
+        msRiSc.value}
 
     private fun GithubContentResponse.responseToRiScResult(
         riScId: String,
@@ -157,7 +191,7 @@ class RiScService(
             agePrivateKey = ageKey,
         )
 
-    fun updateRiSc(
+    suspend fun updateRiSc(
         owner: String,
         repository: String,
         riScId: String,
@@ -165,7 +199,7 @@ class RiScService(
         accessTokens: AccessTokens,
     ): ProcessRiScResultDTO = updateOrCreateRiSc(owner, repository, riScId, content, accessTokens)
 
-    fun createRiSc(
+    suspend fun createRiSc(
         owner: String,
         repository: String,
         content: RiScWrapperObject,
@@ -186,7 +220,7 @@ class RiScService(
         }
     }
 
-    private fun updateOrCreateRiSc(
+    private suspend fun updateOrCreateRiSc(
         owner: String,
         repository: String,
         riScId: String,
@@ -290,4 +324,6 @@ class RiScService(
         )
 
     fun fetchLatestJSONSchema(): GithubContentResponse = githubConnector.fetchLatestJSONSchema()
+
+
 }

--- a/src/main/kotlin/no/risc/risc/models/UserInfo.kt
+++ b/src/main/kotlin/no/risc/risc/models/UserInfo.kt
@@ -6,6 +6,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 data class UserInfo(
     val name: String,
     val email: String,
-) {
-    fun isValid(): Boolean = name.isNotBlank() && email.isNotBlank()
-}
+)


### PR DESCRIPTION
Calls to Github for fetching risc identifiers and similarly fetching the riscs was previously done sequentially. 
This was not slow and not optimal. Now the calls are instead done async to speed up the endpoint.  