### PR TITLE
add config to deploy on gcp

### DIFF
--- a/.github/workflows/deploy-on-gcp.yml
+++ b/.github/workflows/deploy-on-gcp.yml
@@ -1,0 +1,29 @@
+name: Deploy to Cloud Run
+on:
+  workflow_run:
+    workflows: ["Build and push image to GCP"]
+    types:
+      - completed
+
+env:
+  IMAGE_URL: 'europe-north1-docker.pgk.dev/spire-ros-5lmr/kv-ros/backend:latest'
+  SERVICE_NAME: 'kv-ros-backend'
+
+jobs:
+  deploy_cloud_run:
+    name: 'Deploy latest image on Cloud Run'
+    runs-on: ubuntu-latests
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: ${{ secrets.GCS_ACC_KEY_JSON }}
+    - id: 'deploy'
+      uses: 'google-github-actions/deploy-cloudrun@v2'
+      with:
+        service: $SERVICE_NAME
+        image: $IMAGE_URL
+


### PR DESCRIPTION
Use the `google-github-actions/deploy-cloudrun` action to deploy the latest backend image on GCP when a new image is successfully created and uploaded. 