### PR TITLE
Fix json schema to allow empty strings in actions-url field

### DIFF
--- a/docs/risc_schema_en_v3_3.json
+++ b/docs/risc_schema_en_v3_3.json
@@ -150,7 +150,7 @@
     "url": {
       "type": "string",
       "format": "uri",
-      "pattern": "^https?://"
+      "pattern": "^(?:(https?|s?ftp):\\/\\/)?(?:([\\w-]+)\\.)?([\\w-]+)\\.([\\w]+)\\/?(?:([^?#$]+))?(?:\\?([^#$]+))?(?:#(.*))?$"
     },
     "scenario": {
       "type": "object",
@@ -248,7 +248,13 @@
           "type": "string"
         },
         "url": {
-          "$ref": "#/$defs/url"
+          "anyOf": [
+            {"$ref": "#/$defs/url"},
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "owner": {
           "type": "string"

--- a/docs/risc_schema_en_v4_0.json
+++ b/docs/risc_schema_en_v4_0.json
@@ -150,7 +150,7 @@
     "url": {
       "type": "string",
       "format": "uri",
-      "pattern": "^https?://"
+      "pattern": "^(?:(https?|s?ftp):\\/\\/)?(?:([\\w-]+)\\.)?([\\w-]+)\\.([\\w]+)\\/?(?:([^?#$]+))?(?:\\?([^#$]+))?(?:#(.*))?$"
     },
     "scenario": {
       "type": "object",
@@ -247,7 +247,13 @@
           "type": "string"
         },
         "url": {
-          "$ref": "#/$defs/url"
+          "anyOf": [
+            {"$ref": "#/$defs/url"},
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "status": {
           "type": "string",


### PR DESCRIPTION
Pga regex pattern validering ble ikkje tiltak med tomme url-er godkjent datastruktur.

Endret feltet til å godkjenne tomme strings i tillegg.