### PR TITLE
Getting baseUrl to cryptoservice through environment variables

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="✨Local Server" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="dev" />
+    <option name="ACTIVE_PROFILES" value="local" />
     <envs>
       <env name="GITHUB_APP_ID" value="827078" />
       <env name="GITHUB_INSTALLATION_ID" value="48036152" />

--- a/src/main/kotlin/no/risc/config/CryptoServiceConfig.kt
+++ b/src/main/kotlin/no/risc/config/CryptoServiceConfig.kt
@@ -1,0 +1,10 @@
+package no.risc.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "crypto-service")
+class CryptoServiceConfig {
+    lateinit var baseUrl: String
+}

--- a/src/main/kotlin/no/risc/infra/connector/CryptoServiceConnector.kt
+++ b/src/main/kotlin/no/risc/infra/connector/CryptoServiceConnector.kt
@@ -1,10 +1,9 @@
 package no.risc.infra.connector
 
+import no.risc.config.CryptoServiceConfig
 import org.springframework.stereotype.Component
 
 @Component
 class CryptoServiceConnector(
-    baseUrl: String = "http://localhost:8084",
-) : WebClientConnector(baseUrl) {
-
-}
+    cryptoServiceConfig: CryptoServiceConfig,
+) : WebClientConnector(cryptoServiceConfig.baseUrl)

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -112,7 +112,7 @@ class RiScService(
     @Value("\${sops.ageKey}") val ageKey: String,
     @Value("\${filename.prefix}") val filenamePrefix: String,
     private val cryptoService: CryptoServiceIntegration,
-    @Value("\${featureToggle.useCryptoService}") val useCryptoService: Boolean,
+    @Value("\${featureToggle.useCryptoServiceForEncryption}") val useCryptoServiceForEncryption: Boolean,
 ) {
     private val logger = LoggerFactory.getLogger(RiScService::class.java)
     suspend fun fetchAllRiScIds(
@@ -285,7 +285,7 @@ class RiScService(
 
         val config = removePathRegex(sopsConfig.data())
 
-        val encryptedData: String = if (useCryptoService) {
+        val encryptedData: String = if (useCryptoServiceForEncryption) {
             cryptoService.encryptPost(content.riSc, config, accessTokens.gcpAccessToken, riScId)
         } else {
             SOPS.encrypt(content.riSc, config, accessTokens.gcpAccessToken, riScId)

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,1 @@
+cryptoService.baseUrl=http://localhost:8084

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,1 +1,2 @@
+featureToggle.useCryptoServiceForEncryption = true
 cryptoService.baseUrl=http://localhost:8084

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,5 +13,5 @@ management.endpoint.health.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health
 
-featureToggle.useCryptoService = false
+featureToggle.useCryptoServiceForEncryption = false
 cryptoService.baseUrl=${CRYPTO_SERVICE_URL}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,4 @@ management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health
 
 featureToggle.useCryptoService = false
+cryptoService.baseUrl=${CRYPTO_SERVICE_URL}


### PR DESCRIPTION
Lenke til cryptoservice bare tidligere en hardkodet lenke til http://localhost:8084. Lenken hentes nå gjennom application properties, som skal muliggjøre å kontakte cryptoservice på SKIP. 