### PR TITLE
Fjerne ktlint-commit fra git blame loggen

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Introduced ktlint
+d695338bda18a80afcf0ff11e117f97d6826063f


### PR DESCRIPTION
Fjerner ktlint-commit fra git blame loggen slik at det blir lettere å se hvilken commit koden egentlig ble introdusert i.