### PR TITLE
Fjern age_private_key fra header mot /decrypt

### DIFF
--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -85,7 +85,6 @@ class CryptoServiceIntegration(
                             .build()
                     }
                     .header("gcpAccessToken", gcpAccessToken.value)
-                    .header("agePrivateKey", agePrivateKey)
                     .bodyValue(ciphertext)
                     .retrieve()
                     .bodyToMono(String::class.java)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,5 +13,5 @@ management.endpoint.health.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health
 featureToggle.useCryptoServiceForEncryption=true
-featureToggle.useCryptoServiceForDecrypt=false
+featureToggle.useCryptoServiceForDecrypt=true
 cryptoService.baseUrl=${CRYPTO_SERVICE_URL}


### PR DESCRIPTION
Vi trenger ikke lenger å sette age_private_key i headeren når vi kaller decrypt. Ref: https://github.com/kartverket/backstage-plugin-risk-crypto-service/pull/18. 

Fjerner også agePrivateKey som input til metoden når vi ikke trenger `ISopsEncryption`-interfacet (som er etter at vi har fått fjernet gammel decryptkode), evt kan endre på interfacet.