### PR TITLE
Kast exception istedenfor å returnere det som string

### DIFF
--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -1,5 +1,6 @@
 package no.risc.encryption
 
+import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.infra.connector.CryptoServiceConnector
 import no.risc.infra.connector.models.GCPAccessToken
 import org.slf4j.LoggerFactory
@@ -41,7 +42,10 @@ class CryptoServiceIntegration(
                 .block()
                 .toString()
         } catch (e: Exception) {
-            "Exception caught: ${e.stackTraceToString()}"
+            throw SopsEncryptionException(
+                message = e.stackTraceToString(),
+                riScId = riScId
+            )
         }
     }
 

--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -44,7 +44,7 @@ class CryptoServiceIntegration(
         } catch (e: Exception) {
             throw SopsEncryptionException(
                 message = e.stackTraceToString(),
-                riScId = riScId
+                riScId = riScId,
             )
         }
     }


### PR DESCRIPTION
Når encrypt-kallet mot crypto-service går galt, så har vi returnert stacktracen som en string, og det er det som lagres som en ros. Kast heller feilen slik at vi ikke overskriver det faktiske innholdet.