### PR TITLE
feature: include migration version

### DIFF
--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -55,13 +55,26 @@ data class RiScContentResultDTO(
         MigrationStatus(
             migrationChanges = false,
             migrationRequiresNewApproval = false,
+            migrationVersions = MigrationVersions(
+                fromVersion = null,
+                toVersion = null,
+            ),
         ),
+
+
 )
 
 @Serializable
 data class MigrationStatus(
     val migrationChanges: Boolean,
     val migrationRequiresNewApproval: Boolean,
+    val migrationVersions: MigrationVersions,
+)
+
+@Serializable
+data class MigrationVersions(
+    var fromVersion: String?,
+    var toVersion: String?
 )
 
 data class PublishRiScResultDTO(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -55,13 +55,12 @@ data class RiScContentResultDTO(
         MigrationStatus(
             migrationChanges = false,
             migrationRequiresNewApproval = false,
-            migrationVersions = MigrationVersions(
-                fromVersion = null,
-                toVersion = null,
-            ),
+            migrationVersions =
+                MigrationVersions(
+                    fromVersion = null,
+                    toVersion = null,
+                ),
         ),
-
-
 )
 
 @Serializable
@@ -74,7 +73,7 @@ data class MigrationStatus(
 @Serializable
 data class MigrationVersions(
     var fromVersion: String?,
-    var toVersion: String?
+    var toVersion: String?,
 )
 
 data class PublishRiScResultDTO(

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -25,10 +25,20 @@ fun migrate(
     val json = Json { ignoreUnknownKeys = true }
     val jsonObject = json.parseToJsonElement(content).jsonObject.toMutableMap()
 
-    val schemaVersion = jsonObject["schemaVersion"]?.jsonPrimitive?.content
+    val schemaVersion = jsonObject["schemaVersion"]?.jsonPrimitive?.content ?: return obj
 
-    if (schemaVersion == null || schemaVersion == latestSupportedVersion) {
+    if (schemaVersion == latestSupportedVersion)
+    {
+        if (obj.migrationStatus.migrationVersions.fromVersion != null) {
+        // Set the toVersion to the latestSupportedVersion
+        obj.migrationStatus.migrationVersions.toVersion = latestSupportedVersion
+        }
         return obj
+    }
+
+    // Set the fromVersion only if it's not already set
+    if (obj.migrationStatus.migrationVersions.fromVersion == null) {
+        obj.migrationStatus.migrationVersions.fromVersion = schemaVersion
     }
 
     val nextVersionObj =
@@ -44,11 +54,9 @@ fun migrate(
 // Update RiSc scenarios from schemaVersion 3.2 to 3.3. This is necessary because 3.3 is backwards compatible,
 // and modifications can only be made when the schemaVersion is 3.3.
 fun migrateTo32To33(obj: RiScContentResultDTO): RiScContentResultDTO {
-    if (obj.riScContent == null) {
-        return obj
-    }
 
-    val migratedSchemaVersion = obj.riScContent.replace("\"schemaVersion\": \"3.2\"", "\"schemaVersion\": \"3.3\"")
+
+    val migratedSchemaVersion = obj.riScContent!!.replace("\"schemaVersion\": \"3.2\"", "\"schemaVersion\": \"3.3\"")
     return obj.copy(riScContent = migratedSchemaVersion)
 }
 
@@ -70,11 +78,8 @@ fun migrateTo32To33(obj: RiScContentResultDTO): RiScContentResultDTO {
  */
 @OptIn(ExperimentalSerializationApi::class)
 fun migrateFrom33To40(obj: RiScContentResultDTO): RiScContentResultDTO {
-    if (obj.riScContent == null) {
-        return obj
-    }
 
-    var content = obj.riScContent
+    var content = obj.riScContent!!
 
     val json = Json { ignoreUnknownKeys = true }
     val jsonObject = json.parseToJsonElement(content).jsonObject.toMutableMap()
@@ -155,6 +160,7 @@ fun migrateFrom33To40(obj: RiScContentResultDTO): RiScContentResultDTO {
             MigrationStatus(
                 migrationChanges = true,
                 migrationRequiresNewApproval = true,
+                migrationVersions = obj.migrationStatus.migrationVersions,
             ),
     )
 }

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -27,11 +27,10 @@ fun migrate(
 
     val schemaVersion = jsonObject["schemaVersion"]?.jsonPrimitive?.content ?: return obj
 
-    if (schemaVersion == latestSupportedVersion)
-    {
+    if (schemaVersion == latestSupportedVersion) {
         if (obj.migrationStatus.migrationVersions.fromVersion != null) {
-        // Set the toVersion to the latestSupportedVersion
-        obj.migrationStatus.migrationVersions.toVersion = latestSupportedVersion
+            // Set the toVersion to the latestSupportedVersion
+            obj.migrationStatus.migrationVersions.toVersion = latestSupportedVersion
         }
         return obj
     }
@@ -54,8 +53,6 @@ fun migrate(
 // Update RiSc scenarios from schemaVersion 3.2 to 3.3. This is necessary because 3.3 is backwards compatible,
 // and modifications can only be made when the schemaVersion is 3.3.
 fun migrateTo32To33(obj: RiScContentResultDTO): RiScContentResultDTO {
-
-
     val migratedSchemaVersion = obj.riScContent!!.replace("\"schemaVersion\": \"3.2\"", "\"schemaVersion\": \"3.3\"")
     return obj.copy(riScContent = migratedSchemaVersion)
 }
@@ -78,7 +75,6 @@ fun migrateTo32To33(obj: RiScContentResultDTO): RiScContentResultDTO {
  */
 @OptIn(ExperimentalSerializationApi::class)
 fun migrateFrom33To40(obj: RiScContentResultDTO): RiScContentResultDTO {
-
     var content = obj.riScContent!!
 
     val json = Json { ignoreUnknownKeys = true }

--- a/src/test/kotlin/no/risc/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/MigrationFunctionTests.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.risc.risc.ContentStatus
 import no.risc.risc.MigrationStatus
+import no.risc.risc.MigrationVersions
 import no.risc.risc.RiScContentResultDTO
 import no.risc.risc.RiScStatus
 import no.risc.utils.migrate
@@ -35,6 +36,7 @@ class MigrationFunctionTests {
                     MigrationStatus(
                         migrationChanges = false,
                         migrationRequiresNewApproval = false,
+                        migrationVersions = MigrationVersions(fromVersion = null, toVersion = null),
                     ),
             )
         val migratedObject = migrateTo32To33(obj)
@@ -64,6 +66,7 @@ class MigrationFunctionTests {
                     MigrationStatus(
                         migrationChanges = false,
                         migrationRequiresNewApproval = true,
+                        migrationVersions = MigrationVersions(fromVersion = null, toVersion = null),
                     ),
             )
         val migratedObject = migrateFrom33To40(obj)
@@ -126,6 +129,7 @@ class MigrationFunctionTests {
                     MigrationStatus(
                         migrationChanges = false,
                         migrationRequiresNewApproval = true,
+                        migrationVersions = MigrationVersions(fromVersion = null, toVersion = null),
                     ),
             )
         val migratedObject = migrateFrom33To40(obj)
@@ -154,6 +158,7 @@ class MigrationFunctionTests {
                     MigrationStatus(
                         migrationChanges = false,
                         migrationRequiresNewApproval = false,
+                        migrationVersions = MigrationVersions(fromVersion = null, toVersion = null),
                     ),
             )
         val migratedObject = migrate(obj, latestSupportedVersion)


### PR DESCRIPTION
Now includes which schema version the migration started and ended on in the response to fetch all riscs. 