### PR TITLE
chore: fjern sops fra dockerfil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,13 @@ RUN apk update && apk upgrade
 FROM eclipse-temurin:21
 
 # Create application directory and subdirectories
-RUN mkdir -p /app /app/logs /app/tmp /usr/local/bin
+RUN mkdir -p /app /app/logs /app/tmp
 
-ARG SOPS_AMD64="https://github.com/bekk/sops/releases/download/v1.2/sops-v1.2.linux.amd64"
-ARG SOPS_ARM64="https://github.com/bekk/sops/releases/download/v1.2/sops-v1.2.linux.arm64"
-
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      curl -L $SOPS_AMD64 -o /usr/local/bin/sops; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-      curl -L $SOPS_ARM64 -o /usr/local/bin/sops; \
-    else \
-      echo "Unsupported architecture"; \
-      exit 1; \
-    fi \
-    && chmod +x /usr/local/bin/sops
 COPY --from=build /build/libs/*.jar /app/backend.jar
+COPY --from=build /src/main/resources/schemas schemas
 
 # Add non-root user og endre rettigheter
-RUN useradd user && chown -R user:user /app /usr/local/bin /app/logs /app/tmp
+RUN useradd user && chown -R user:user /app /app/logs /app/tmp
 
 # Bytt til non-root user
 USER user

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM eclipse-temurin:21
 RUN mkdir -p /app /app/logs /app/tmp
 
 COPY --from=build /build/libs/*.jar /app/backend.jar
-COPY --from=build /src/main/resources/schemas schemas
 
 # Add non-root user og endre rettigheter
 RUN useradd user && chown -R user:user /app /app/logs /app/tmp


### PR DESCRIPTION
Fjern sops fra dockerfil siden den kun blir brukt i crypto-service