### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Kartverket.dev
 repo_types: [InternalApi]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,56 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "backstage-plugin-risk-scorecard-backend"
+  tags:
+  - "internal"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "skvis"
+  system: "utviklerportal"
+  providesApis:
+  - "backstage-plugin-risk-scorecard-backend-api"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_backstage-plugin-risk-scorecard-backend"
+  title: "Security Champion backstage-plugin-risk-scorecard-backend"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "jorn-ola-birkeland"
+  children:
+  - "resource:backstage-plugin-risk-scorecard-backend"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "backstage-plugin-risk-scorecard-backend"
+  links:
+  - url: "https://github.com/kartverket/backstage-plugin-risk-scorecard-backend"
+    title: "backstage-plugin-risk-scorecard-backend på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_backstage-plugin-risk-scorecard-backend"
+  dependencyOf:
+  - "component:backstage-plugin-risk-scorecard-backend"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "API"
+metadata:
+  name: "backstage-plugin-risk-scorecard-backend-api"
+  tags:
+  - "internal"
+spec:
+  type: "openapi"
+  lifecycle: "production"
+  owner: "skvis"
+  definition: |
+    openapi: "3.0.0"
+    info:
+        title: backstage-plugin-risk-scorecard-backend API
+    paths:


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.