### PR TITLE
GitHub App only in prod

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -8,7 +8,6 @@
     </envs>
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/.env" />
-      <option value="$PROJECT_DIR$/.env.local" />
     </option>
     <module name="backstage-plugin-risk-scorecard-backend.main" />
     <option name="PASS_PARENT_ENVS" value="false" />

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -39,9 +39,7 @@ class RiScController(
             repositoryName,
             AccessTokens(
                 gcpAccessToken = GCPAccessToken(gcpAccessToken),
-                githubAccessToken =
-                    gitHubAccessToken?.let { GithubAccessToken(gitHubAccessToken) }
-                        ?: gitHubAppService.getInstallationToken(),
+                githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
             ),
             "4",
         )
@@ -59,9 +57,7 @@ class RiScController(
             repositoryName,
             AccessTokens(
                 gcpAccessToken = GCPAccessToken(gcpAccessToken),
-                githubAccessToken =
-                    gitHubAccessToken?.let { GithubAccessToken(gitHubAccessToken) }
-                        ?: gitHubAppService.getInstallationToken(),
+                githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
             ),
             latestSupportedVersion,
         )

--- a/src/main/kotlin/no/risc/sops/SopsController.kt
+++ b/src/main/kotlin/no/risc/sops/SopsController.kt
@@ -38,9 +38,7 @@ class SopsController(
             repositoryOwner,
             repositoryName,
             AccessTokens(
-                githubAccessToken =
-                    gitHubAccessToken?.let { GithubAccessToken(gitHubAccessToken) }
-                        ?: gitHubAppService.getInstallationToken(),
+                githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
                 gcpAccessToken = GCPAccessToken(gcpAccessToken),
             ),
         )


### PR DESCRIPTION
When running locally, a GitHub access token must be provided for all requests and the GitHub Read App is now only used in prod.