### PR TITLE
Trekker ut SOPS config rett fra kryptert tekst

### DIFF
--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -42,7 +42,11 @@ class CryptoServiceIntegration(
                 .retrieve()
                 .bodyToMono(String::class.java)
                 .block()
-                .toString()
+                ?.toString()
+                ?: throw SopsEncryptionException(
+                    message = "Failed to encrypt file",
+                    riScId = riScId,
+                )
         } catch (e: Exception) {
             throw SopsEncryptionException(
                 message = e.stackTraceToString(),

--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -76,10 +76,8 @@ class CryptoServiceIntegration(
                         0,
                         20,
                     )
-                } to ${decryptedFileWithConfig.riSc.toString().substring(0, 20)}",
+                } to ${decryptedFileWithConfig.riSc.substring(0, 20)}",
             )
-            println("\n\n")
-            println(decryptedFileWithConfig.sopsConfig)
             decryptedFileWithConfig
         } catch (e: Exception) {
             throw e

--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -58,26 +58,27 @@ class CryptoServiceIntegration(
     suspend fun decrypt(
         ciphertext: String,
         gcpAccessToken: GCPAccessToken,
-    ): String =
+    ): Pair<String, String> =
         try {
             LOGGER.info("Trying to decrypt ciphertext: ${ciphertext.substring(0, 14)}")
-            val decryptedFile =
+            val decryptedFileWithConfig =
                 cryptoServiceConnector.webClient
                     .post()
                     .uri("/decrypt")
                     .header("gcpAccessToken", gcpAccessToken.value)
                     .bodyValue(ciphertext)
                     .retrieve()
-                    .awaitBody<String>()
+                    .awaitBody<Pair<String, String>>()
             LOGGER.info(
                 "Successfully decrypted ciphertext ${
                     ciphertext.substring(
                         0,
                         14,
                     )
-                } to ${decryptedFile.substring(3, 10)}",
+                } to ${decryptedFileWithConfig.first.substring(3, 10)}",
             )
-            decryptedFile
+            LOGGER.info("Decrypted config: ${decryptedFileWithConfig.second}")
+            decryptedFileWithConfig
         } catch (e: Exception) {
             throw (SOPSDecryptionException(message = "Failed to decrypt file"))
         }

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -479,6 +479,7 @@ class GithubConnector(
         accessToken: String,
         defaultBranch: String,
     ): String? {
+        LOGGER.info("Using GitHub access token: $accessToken")
         val latestShaForMainBranch =
             fetchLatestShaForDefaultBranch(owner, repository, accessToken, defaultBranch) ?: return null
         return postNewBranchToGithub(

--- a/src/main/kotlin/no/risc/google/GoogleControllerIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleControllerIntegration.kt
@@ -1,0 +1,29 @@
+package no.risc.google
+
+import no.risc.infra.connector.models.GCPAccessToken
+import no.risc.sops.model.GcpCryptoKeyObject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/google")
+class GoogleControllerIntegration(
+    private val googleServiceIntegration: GoogleServiceIntegration,
+) {
+    companion object {
+        val LOGGER: Logger = LoggerFactory.getLogger(GoogleControllerIntegration::class.java)
+    }
+
+    @GetMapping("/gcpCryptoKeys")
+    suspend fun getGcpCryptoKeys(
+        @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
+        @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String? = null,
+    ): List<GcpCryptoKeyObject> {
+        LOGGER.info("Fetching GCP crypto keys")
+        return googleServiceIntegration.getGcpCryptoKeys(GCPAccessToken(gcpAccessToken))
+    }
+}

--- a/src/main/kotlin/no/risc/google/model/GcpProjectId.kt
+++ b/src/main/kotlin/no/risc/google/model/GcpProjectId.kt
@@ -1,0 +1,21 @@
+package no.risc.google.model
+
+import no.risc.utils.ValidationResult
+
+data class GcpProjectId(
+    val value: String = "",
+)
+
+fun GcpProjectId.getValidationResult() =
+    if (Regex("^(\\w+-)+\\w+$").matches(value)) {
+        ValidationResult(true)
+    } else {
+        ValidationResult(false, "Invalid format of GCP Project ID: '$value'")
+    }
+
+fun GcpProjectId.getRiScKeyRing() = "${value.split("-").dropLast(2).joinToString("-")}-risc-key-ring"
+
+fun GcpProjectId.getRiScCryptoKey() = "${value.split("-").dropLast(2).joinToString("-")}-risc-crypto-key"
+
+fun GcpProjectId.getRiScCryptoKeyResourceId() =
+    "projects/$value/locations/europe-north1/keyRings/${getRiScKeyRing()}/cryptoKeys/${getRiScCryptoKey()}"

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -95,17 +95,18 @@ class RiScController(
         @PathVariable id: String,
         @PathVariable repositoryName: String,
         @RequestBody riSc: RiScWrapperObject,
-    ) = riScService.updateRiSc(
-        repositoryOwner,
-        repositoryName,
-        id,
-        riSc,
-        AccessTokens(
+    ) =
+        riScService.updateRiSc(
+            repositoryOwner,
+            repositoryName,
+            id,
+            riSc,
+            AccessTokens(
             gcpAccessToken = GCPAccessToken(gcpAccessToken),
             githubAccessToken = GithubAccessToken(gitHubAccessToken),
         ),
-        githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, gitHubAccessToken),
-    )
+            githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, gitHubAccessToken),
+        )
 
     @PostMapping("/{repositoryOwner}/{repositoryName}/publish/{id}", produces = ["application/json"])
     fun sendRiScForPublishing(

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -51,16 +51,19 @@ class RiScController(
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
         @PathVariable latestSupportedVersion: String,
-    ): List<RiScContentResultDTO> =
-        riScService.fetchAllRiScs(
-            repositoryOwner,
-            repositoryName,
-            AccessTokens(
-                gcpAccessToken = GCPAccessToken(gcpAccessToken),
-                githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
-            ),
-            latestSupportedVersion,
-        )
+    ): List<RiScContentResultDTO> {
+        val result =
+            riScService.fetchAllRiScs(
+                repositoryOwner,
+                repositoryName,
+                AccessTokens(
+                    gcpAccessToken = GCPAccessToken(gcpAccessToken),
+                    githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
+                ),
+                latestSupportedVersion,
+            )
+        return result
+    }
 
     @PostMapping("/{repositoryOwner}/{repositoryName}")
     suspend fun createNewRiSc(

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -95,18 +95,17 @@ class RiScController(
         @PathVariable id: String,
         @PathVariable repositoryName: String,
         @RequestBody riSc: RiScWrapperObject,
-    ) =
-        riScService.updateRiSc(
-            repositoryOwner,
-            repositoryName,
-            id,
-            riSc,
-            AccessTokens(
+    ) = riScService.updateRiSc(
+        repositoryOwner,
+        repositoryName,
+        id,
+        riSc,
+        AccessTokens(
             gcpAccessToken = GCPAccessToken(gcpAccessToken),
             githubAccessToken = GithubAccessToken(gitHubAccessToken),
         ),
-            githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, gitHubAccessToken),
-        )
+        githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, gitHubAccessToken),
+    )
 
     @PostMapping("/{repositoryOwner}/{repositoryName}/publish/{id}", produces = ["application/json"])
     fun sendRiScForPublishing(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -54,6 +54,7 @@ data class CreateRiScResultDTO(
     val status: ProcessingStatus,
     val statusMessage: String,
     val riScContent: String?,
+    val sopsConfig: SopsConfig,
 )
 
 @Serializable
@@ -515,6 +516,7 @@ class RiScService(
                     ProcessingStatus.CreatedRiSc,
                     "New RiSc was created",
                     riScContentWrapperObject.riSc,
+                    riScContentWrapperObject.sopsConfig,
                 )
             } else {
                 throw CreatingRiScException(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -20,7 +20,6 @@ import no.risc.initRiSc.InitRiScServiceIntegration
 import no.risc.risc.models.DifferenceDTO
 import no.risc.risc.models.RiScWrapperObject
 import no.risc.risc.models.UserInfo
-import no.risc.sops.model.SopsConfigDTO
 import no.risc.sops.model.SopsConfig
 import no.risc.utils.Difference
 import no.risc.utils.DifferenceException

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -15,7 +15,6 @@ import no.risc.github.GithubConnector
 import no.risc.github.GithubContentResponse
 import no.risc.github.GithubPullRequestObject
 import no.risc.github.GithubStatus
-import no.risc.github.models.SopsConfigOnGitHub
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.initRiSc.InitRiScServiceIntegration
@@ -27,7 +26,6 @@ import no.risc.utils.DifferenceException
 import no.risc.utils.diff
 import no.risc.utils.generateRiScId
 import no.risc.utils.migrate
-import no.risc.utils.removePathRegex
 import no.risc.validation.JSONValidator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
@@ -2,10 +2,10 @@ package no.risc.risc.models
 
 import no.risc.sops.model.SopsConfig
 
-data class RiScWrapperObject(
+data class RiScWithConfig(
     val riSc: String,
     val isRequiresNewApproval: Boolean,
     val schemaVersion: String,
-    val userInfo: UserInfo,
+    val userInfo: UserInfo? = null,
     val sopsConfig: SopsConfig,
 )

--- a/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
@@ -4,8 +4,5 @@ import no.risc.sops.model.SopsConfig
 
 data class RiScWithConfig(
     val riSc: String,
-    val isRequiresNewApproval: Boolean,
-    val schemaVersion: String,
-    val userInfo: UserInfo? = null,
     val sopsConfig: SopsConfig,
 )

--- a/src/main/kotlin/no/risc/risc/models/RiScWrapperObject.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiScWrapperObject.kt
@@ -5,4 +5,5 @@ data class RiScWrapperObject(
     val isRequiresNewApproval: Boolean,
     val schemaVersion: String,
     val userInfo: UserInfo,
+    val sopsConfig: String,
 )

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -19,20 +19,25 @@ class AccessTokenValidationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        val repository =
-            Repository(
-                repositoryOwner = request.requestURI.split("/")[3],
-                repositoryName = request.requestURI.split("/")[4],
-            )
-        if (request.method.lowercase() != "get") {
-            validationService.validateAccessTokens(
-                request.getHeader("GCP-Access-Token"),
-                request.getHeader("GitHub-Access-Token"),
-                GitHubPermission.WRITE,
-                repository.repositoryOwner,
-                repository.repositoryName,
-            )
+        try {
+            if (request.method.lowercase() != "get") {
+            val repository =
+                    Repository(
+                        repositoryOwner = request.requestURI.split("/")[3],
+                        repositoryName = request.requestURI.split("/")[4],
+                    )
+
+                validationService.validateAccessTokens(
+                    request.getHeader("GCP-Access-Token"),
+                    request.getHeader("GitHub-Access-Token"),
+                    GitHubPermission.WRITE,
+                    repository.repositoryOwner,
+                    repository.repositoryName,
+                )
+            }
+            filterChain.doFilter(request, response)
+        } catch (e: IndexOutOfBoundsException) {
+            println("${request.requestURI} does not have access token}")
         }
-        filterChain.doFilter(request, response)
     }
 }

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -21,7 +21,7 @@ class AccessTokenValidationFilter(
     ) {
         try {
             if (request.method.lowercase() != "get") {
-            val repository =
+                val repository =
                     Repository(
                         repositoryOwner = request.requestURI.split("/")[3],
                         repositoryName = request.requestURI.split("/")[4],

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -4,7 +4,9 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.annotation.WebFilter
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import no.risc.exception.exceptions.InvalidAccessTokensException
 import no.risc.infra.connector.models.GitHubPermission
+import no.risc.risc.ProcessingStatus
 import no.risc.utils.Repository
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -37,7 +39,9 @@ class AccessTokenValidationFilter(
             }
             filterChain.doFilter(request, response)
         } catch (e: IndexOutOfBoundsException) {
-            println("${request.requestURI} does not have access token}")
+            throw InvalidAccessTokensException(
+                "${request.requestURI} does not have access token}"
+            )
         }
     }
 }

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import no.risc.exception.exceptions.InvalidAccessTokensException
 import no.risc.infra.connector.models.GitHubPermission
-import no.risc.risc.ProcessingStatus
 import no.risc.utils.Repository
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -40,7 +39,7 @@ class AccessTokenValidationFilter(
             filterChain.doFilter(request, response)
         } catch (e: IndexOutOfBoundsException) {
             throw InvalidAccessTokensException(
-                "${request.requestURI} does not have access token}"
+                "${request.requestURI} does not have access token}",
             )
         }
     }

--- a/src/main/kotlin/no/risc/sops/SopsService.kt
+++ b/src/main/kotlin/no/risc/sops/SopsService.kt
@@ -357,7 +357,7 @@ class SopsService(
                 .firstOrNull { !it.gcp_kms.isNullOrEmpty() }
                 ?.gcp_kms
                 ?.firstOrNull()
-                ?.resourceId
+                ?.resource_id
                 ?: throw NoResourceIdFoundException(
                     "No gcp kms resource id could be found",
                     ProcessRiScResultDTO(

--- a/src/main/kotlin/no/risc/sops/SopsService.kt
+++ b/src/main/kotlin/no/risc/sops/SopsService.kt
@@ -205,7 +205,7 @@ class SopsService(
                                 }
                                 SopsConfigDTO(
                                     gcpCryptoKey,
-                                    sopsConfig.getDeveloperPublicKeys(sopsServiceConfig.backendPublicKey)
+                                    sopsConfig.getDeveloperPublicKeys(sopsServiceConfig.backendPublicKey),
                                 )
                             } else {
                                 null

--- a/src/main/kotlin/no/risc/sops/SopsService.kt
+++ b/src/main/kotlin/no/risc/sops/SopsService.kt
@@ -11,6 +11,9 @@ import no.risc.exception.exceptions.NoResourceIdFoundException
 import no.risc.github.GithubConnector
 import no.risc.google.GoogleServiceIntegration
 import no.risc.google.model.GcpIamPermission
+import no.risc.google.model.getRiScCryptoKey
+import no.risc.google.model.getRiScCryptoKeyResourceId
+import no.risc.google.model.getRiScKeyRing
 import no.risc.infra.connector.GcpCloudResourceApiConnector
 import no.risc.infra.connector.GcpKmsApiConnector
 import no.risc.infra.connector.models.AccessTokens
@@ -141,7 +144,6 @@ class SopsService(
                         "Failed to fetch GCP projects",
                         ProcessingStatus.FailedToFetchGcpProjectIds,
                     )
-
             val cryptoKeys =
                 gcpProjectIds
                     .filter { it.value.contains("-prod-") }
@@ -159,6 +161,7 @@ class SopsService(
                             gcpProjectId.value,
                             gcpProjectId.getRiScKeyRing(),
                             gcpProjectId.getRiScCryptoKey(),
+                            gcpProjectId.getRiScCryptoKeyResourceId(),
                             hasAccess.await(),
                         )
                     }.toMutableList()
@@ -202,10 +205,7 @@ class SopsService(
                                 }
                                 SopsConfigDTO(
                                     gcpCryptoKey,
-                                    sopsConfig.getDeveloperPublicKeys(sopsServiceConfig.backendPublicKey),
-                                    sopsBranch == defaultBranch,
-                                    sopsBranch,
-                                    pullRequests.firstOrNull { it.head.ref == sopsBranch }?.toPullRequestObject(),
+                                    sopsConfig.getDeveloperPublicKeys(sopsServiceConfig.backendPublicKey)
                                 )
                             } else {
                                 null
@@ -292,9 +292,6 @@ class SopsService(
             SopsConfigDTO(
                 gcpCryptoKey,
                 publicAgeKeys,
-                false,
-                branch,
-                null,
             ),
         )
     }
@@ -356,11 +353,9 @@ class SopsService(
         gcpAccessToken: GCPAccessToken,
     ): GcpCryptoKeyObject {
         val resourceId =
-            sopsConfig.creationRules
-                .firstOrNull()
-                ?.keyGroups
-                ?.firstOrNull { !it.gcpKms.isNullOrEmpty() }
-                ?.gcpKms
+            sopsConfig.key_groups
+                .firstOrNull { !it.gcp_kms.isNullOrEmpty() }
+                ?.gcp_kms
                 ?.firstOrNull()
                 ?.resourceId
                 ?: throw NoResourceIdFoundException(
@@ -375,6 +370,7 @@ class SopsService(
             resourceId.split("/")[1],
             resourceId.split("/")[5],
             resourceId.split("/").last(),
+            resourceId,
             googleServiceIntegration.testIamPermissions(
                 resourceId,
                 gcpAccessToken,

--- a/src/main/kotlin/no/risc/sops/model/DTOs.kt
+++ b/src/main/kotlin/no/risc/sops/model/DTOs.kt
@@ -20,9 +20,6 @@ data class SopsConfigRequestBody(
 data class SopsConfigDTO(
     val gcpCryptoKey: GcpCryptoKeyObject,
     val publicAgeKeys: List<PublicAgeKey>,
-    val onDefaultBranch: Boolean,
-    val branch: String,
-    val pullRequest: PullRequestObject?,
 )
 
 data class CreateSopsConfigResponseBody(
@@ -53,6 +50,7 @@ data class GcpCryptoKeyObject(
     val projectId: String,
     val keyRing: String,
     val name: String,
+    val resourceId: String,
     val hasEncryptDecryptAccess: Boolean,
 )
 

--- a/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
+++ b/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
@@ -29,8 +29,8 @@ data class SopsConfig(
 
 @Serializable
 data class GcpKmsEntry(
-    @JsonProperty("resource_id") val resourceId: String,
-    @JsonProperty("created_at") val createdAt: String? = null,
+    @JsonProperty("resource_id") val resource_id: String,
+    @JsonProperty("created_at") val created_at: String? = null,
     @JsonProperty("enc") val enc: String? = null,
 )
 
@@ -49,5 +49,5 @@ data class KeyGroup(
 
 @Serializable
 data class ResourceId(
-    @JsonProperty("resource_id") val resourceId: String,
+    @JsonProperty("resource_id") val resource_id: String,
 )

--- a/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
+++ b/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
@@ -3,6 +3,7 @@ package no.risc.sops.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+
 // {key_groups:[{gcp_kms:[{resourse, createdat, enc}], age:[{recipient, enc}]}, age: [{recipient, enc},{recipient, enc}]}, age: [{recipient, enc}]], shamir_threshold: number, lastmodified: "2025-01-31T09:41:08Z", version: string}
 @Serializable
 data class SopsConfig(

--- a/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
+++ b/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
@@ -1,34 +1,53 @@
 package no.risc.sops.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
-
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+// {key_groups:[{gcp_kms:[{resourse, createdat, enc}], age:[{recipient, enc}]}, age: [{recipient, enc},{recipient, enc}]}, age: [{recipient, enc}]], shamir_threshold: number, lastmodified: "2025-01-31T09:41:08Z", version: string}
+@Serializable
 data class SopsConfig(
-    @JsonProperty("creation_rules") val creationRules: List<CreationRule>,
+    @JsonProperty("shamir_threshold") val shamir_threshold: Int,
+    @JsonProperty("key_groups") val key_groups: List<KeyGroup>,
+    @JsonProperty("kms") val kms: List<JsonElement>? = null,
+    @JsonProperty("gcp_kms") val gcpKms: List<GcpKmsEntry>? = null,
+    @JsonProperty("age") val age: List<AgeEntry>? = null,
+    @JsonProperty("lastmodified") val lastModified: String? = null,
+    @JsonProperty("mac") val mac: String? = null,
+    @JsonProperty("unencrypted_suffix") val unencryptedSuffix: String? = null,
+    @JsonProperty("version") val version: String? = null,
 ) {
     fun getDeveloperPublicKeys(backendPublicAgeKey: String): List<PublicAgeKey> =
-        this.creationRules
-            .firstOrNull()
-            ?.keyGroups
-            ?.firstOrNull {
-                it.gcpKms.isNullOrEmpty() &&
-                    it.age?.all { ageKey -> ageKey != backendPublicAgeKey } == true
+        this.key_groups
+            .firstOrNull {
+                it.gcp_kms.isNullOrEmpty() &&
+                    it.age?.all { ageKey -> ageKey.recipient != backendPublicAgeKey } == true
             }?.age
             ?.map {
-                PublicAgeKey(it)
+                PublicAgeKey(it.recipient)
             } ?: emptyList()
 }
 
-data class CreationRule(
-    @JsonProperty("path_regex") val pathRegex: String,
-    @JsonProperty("shamir_threshold") val shamirThreshold: Int,
-    @JsonProperty("key_groups") val keyGroups: List<KeyGroup>,
+@Serializable
+data class GcpKmsEntry(
+    @JsonProperty("resource_id") val resourceId: String,
+    @JsonProperty("created_at") val createdAt: String? = null,
+    @JsonProperty("enc") val enc: String? = null,
 )
 
+@Serializable
+data class AgeEntry(
+    val recipient: String,
+    val enc: String? = null,
+)
+
+@Serializable
 data class KeyGroup(
-    val age: List<String>? = null,
-    @JsonProperty("gcp_kms") val gcpKms: List<ResourceId>? = null,
+    @JsonProperty("gcp_kms") val gcp_kms: List<GcpKmsEntry>? = null,
+    @JsonProperty("hc_vault") val hc_vault: List<JsonElement>? = null,
+    @JsonProperty("age") val age: List<AgeEntry>? = null,
 )
 
+@Serializable
 data class ResourceId(
     @JsonProperty("resource_id") val resourceId: String,
 )

--- a/src/main/kotlin/no/risc/utils/DifferenceComparer.kt
+++ b/src/main/kotlin/no/risc/utils/DifferenceComparer.kt
@@ -52,9 +52,7 @@ object FlatMapRiScUtil {
         fun returnString(
             key: String,
             value: String,
-        ): String {
-            return "/$key: $value"
-        }
+        ): String = "/$key: $value"
 
         return map.flatMap { entry ->
 
@@ -103,11 +101,11 @@ object FlatMapRiScUtil {
     }
 }
 
-private fun List<String>.toDifferenceMap(): Map<String, Any> {
-    return this.associate { it.split(": ").first() to it.split(": ").last() }
-}
+private fun List<String>.toDifferenceMap(): Map<String, Any> = this.associate { it.split(": ").first() to it.split(": ").last() }
 
-class DifferenceException(message: String) : Exception(message)
+class DifferenceException(
+    message: String,
+) : Exception(message)
 
 @Throws(DifferenceException::class)
 fun diff(

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -126,12 +126,15 @@ fun migrateFrom33To40(obj: RiScContentResultDTO): RiScContentResultDTO {
             val actionsArray = scenarioDetails?.get("actions")?.jsonArray?.toMutableList()
             actionsArray?.forEachIndexed { index, actionElement ->
                 val actionObject = actionElement.jsonObject.toMutableMap()
-                actionObject["action"]?.jsonObject?.toMutableMap()?.apply {
-                    this.remove("owner")
-                    this.remove("deadline")
-                }?.let { updatedAction ->
-                    actionObject["action"] = JsonObject(updatedAction)
-                }
+                actionObject["action"]
+                    ?.jsonObject
+                    ?.toMutableMap()
+                    ?.apply {
+                        this.remove("owner")
+                        this.remove("deadline")
+                    }?.let { updatedAction ->
+                        actionObject["action"] = JsonObject(updatedAction)
+                    }
                 actionsArray[index] = JsonObject(actionObject)
             }
             actionsArray?.let { scenarioDetails["actions"] = JsonArray(it) }


### PR DESCRIPTION
Bakgrunn:
Ønsker et oppsett for kryptere/dekryptere uten egen sops.yaml fil.

Løsning:
1. Henter kryptert tekst som vanlig fra github, men ikke sops.yaml. Videresender kun kryptert tekst til Crypto-service.
2. Fra crypto-service: mottar dekryptert tekst samt en config for den spesifikke RoSen. (Mottar et Pair<String, String>)
3. Sender dekryptert-tekst med sops-config til frontend.
4. Fra frontend: Mottar plain-tekst + en sops config. Sender denne til Crypto-service for kryptering.