### PR TITLE
Filter out platform key

### DIFF
--- a/src/main/kotlin/no/risc/sops/SopsController.kt
+++ b/src/main/kotlin/no/risc/sops/SopsController.kt
@@ -5,12 +5,10 @@ import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.infra.connector.models.GithubAccessToken
 import no.risc.sops.model.CreateSopsConfigResponseBody
-import no.risc.sops.model.GetSopsConfigResponseBody
 import no.risc.sops.model.SopsConfigRequestBody
 import no.risc.sops.model.UpdateSopsConfigResponseBody
 import no.risc.utils.Validator
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -27,22 +25,6 @@ class SopsController(
     private val sopsService: SopsService,
     private val gitHubAppService: GitHubAppService,
 ) {
-    @GetMapping("/{repositoryOwner}/{repositoryName}")
-    suspend fun getSopsConfig(
-        @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String? = null,
-        @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
-        @PathVariable("repositoryOwner") repositoryOwner: String,
-        @PathVariable("repositoryName") repositoryName: String,
-    ): GetSopsConfigResponseBody =
-        sopsService.getSopsConfigs(
-            repositoryOwner,
-            repositoryName,
-            AccessTokens(
-                githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
-                gcpAccessToken = GCPAccessToken(gcpAccessToken),
-            ),
-        )
-
     @PutMapping("/{repositoryOwner}/{repositoryName}")
     suspend fun createSopsConfig(
         @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String,

--- a/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
+++ b/src/main/kotlin/no/risc/sops/model/SopsConfig.kt
@@ -8,25 +8,15 @@ import kotlinx.serialization.json.JsonElement
 @Serializable
 data class SopsConfig(
     @JsonProperty("shamir_threshold") val shamir_threshold: Int,
-    @JsonProperty("key_groups") val key_groups: List<KeyGroup>,
+    @JsonProperty("key_groups") val key_groups: List<KeyGroup>?,
     @JsonProperty("kms") val kms: List<JsonElement>? = null,
-    @JsonProperty("gcp_kms") val gcpKms: List<GcpKmsEntry>? = null,
+    @JsonProperty("gcp_kms") val gcpKms: List<GcpKmsEntry>,
     @JsonProperty("age") val age: List<AgeEntry>? = null,
     @JsonProperty("lastmodified") val lastModified: String? = null,
     @JsonProperty("mac") val mac: String? = null,
     @JsonProperty("unencrypted_suffix") val unencryptedSuffix: String? = null,
     @JsonProperty("version") val version: String? = null,
-) {
-    fun getDeveloperPublicKeys(backendPublicAgeKey: String): List<PublicAgeKey> =
-        this.key_groups
-            .firstOrNull {
-                it.gcp_kms.isNullOrEmpty() &&
-                    it.age?.all { ageKey -> ageKey.recipient != backendPublicAgeKey } == true
-            }?.age
-            ?.map {
-                PublicAgeKey(it.recipient)
-            } ?: emptyList()
-}
+)
 
 @Serializable
 data class GcpKmsEntry(


### PR DESCRIPTION
Relatert til: https://github.com/kartverket/backstage-plugin-risk-crypto-service/pull/84

Optimaliserer håndteringen av sops-config ved å:
• Filtrere ut organisasjonsnøkler i cryptotjenesten for å unngå unødvendig prosessering.
• Bruke gcp_kms og age variablene direkte, i stedet for KeyGroup, for en mer effektiv tilgang til nøkkeldata.
• Sende gcp_kms direkte til frontend, noe som forenkler visningen av nøkkelinnholdet uten å måtte søke gjennom key_groups.
• Filtrere ut alle CISO-nøkler i cryptotjenesten, slik at frontend bare viser alle utviklerrelaterte age-nøkler uten å ta stilling til om noen av de er backend eller CISO-nøkkel.