### PR TITLE
Use named args

### DIFF
--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -33,7 +33,12 @@ class CryptoServiceIntegration(
         riScId: String,
     ): String {
         val encryptionRequest =
-            EncryptionRequest(text = text, config = sopsConfig, gcpAccessToken = gcpAccessToken.value, riScId = riScId)
+            EncryptionRequest(
+                text = text,
+                config = sopsConfig,
+                gcpAccessToken = gcpAccessToken.value,
+                riScId = riScId,
+            )
 
         return try {
             cryptoServiceConnector.webClient
@@ -43,11 +48,10 @@ class CryptoServiceIntegration(
                 .retrieve()
                 .bodyToMono(String::class.java)
                 .block()
-                ?.toString()
-                ?: throw SopsEncryptionException(
-                    message = "Failed to encrypt file",
-                    riScId = riScId,
-                )
+                ?.toString() ?: throw SopsEncryptionException(
+                message = "Failed to encrypt file",
+                riScId = riScId,
+            )
         } catch (e: Exception) {
             throw SopsEncryptionException(
                 message = e.stackTraceToString(),

--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -47,16 +47,16 @@ internal class GlobalExceptionHandler {
         logger.error(ex.message, ex)
         return if (ex.onUpdateOfRiSC) {
             ProcessRiScResultDTO(
-                ex.riScId,
-                ProcessingStatus.ErrorWhenUpdatingRiSc,
-                "Could not fetch JSON schema",
+                riScId = ex.riScId,
+                status = ProcessingStatus.ErrorWhenUpdatingRiSc,
+                statusMessage = "Could not fetch JSON schema",
             )
         } else {
             RiScContentResultDTO(
-                ex.riScId,
-                ContentStatus.SchemaNotFound,
-                null,
-                null,
+                riScId = ex.riScId,
+                status = ContentStatus.SchemaNotFound,
+                riScStatus = null,
+                riScContent = null,
             )
         }
     }
@@ -67,9 +67,9 @@ internal class GlobalExceptionHandler {
     fun handleRiScNotValidOnUpdateException(ex: RiScNotValidOnUpdateException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenUpdatingRiSc,
-            ex.validationError,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenUpdatingRiSc,
+            statusMessage = ex.validationError,
         )
     }
 
@@ -79,10 +79,10 @@ internal class GlobalExceptionHandler {
     fun handleRiScNotValidOnFetchException(ex: RiScNotValidOnFetchException): RiScContentResultDTO {
         logger.error(ex.message, ex)
         return RiScContentResultDTO(
-            ex.riScId,
-            ContentStatus.SchemaValidationFailed,
-            null,
-            null,
+            riScId = ex.riScId,
+            status = ContentStatus.SchemaValidationFailed,
+            riScStatus = null,
+            riScContent = null,
         )
     }
 
@@ -92,9 +92,9 @@ internal class GlobalExceptionHandler {
     fun handleSopsConfigFetchException(ex: SopsConfigFetchException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenUpdatingRiSc,
-            ex.responseMessage,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenUpdatingRiSc,
+            statusMessage = ex.responseMessage,
         )
     }
 
@@ -104,9 +104,9 @@ internal class GlobalExceptionHandler {
     fun handleSopsEncryptionException(ex: SopsEncryptionException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenUpdatingRiSc,
-            "Could not encrypt RiSc",
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenUpdatingRiSc,
+            statusMessage = "Could not encrypt RiSc",
         )
     }
 
@@ -116,8 +116,8 @@ internal class GlobalExceptionHandler {
     fun handleSopsDecryptionException(ex: SOPSDecryptionException): DecryptionFailure {
         logger.error(ex.message, ex)
         return DecryptionFailure(
-            ContentStatus.DecryptionFailed,
-            ex.message,
+            status = ContentStatus.DecryptionFailed,
+            message = ex.message,
         )
     }
 
@@ -127,9 +127,9 @@ internal class GlobalExceptionHandler {
     fun handleUpdatingRiScException(ex: UpdatingRiScException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenUpdatingRiSc,
-            ex.message,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenUpdatingRiSc,
+            statusMessage = ex.message,
         )
     }
 
@@ -147,9 +147,9 @@ internal class GlobalExceptionHandler {
     fun handleCreatePullRequestException(ex: CreatePullRequestException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenCreatingPullRequest,
-            ex.message,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenCreatingPullRequest,
+            statusMessage = ex.message,
         )
     }
 
@@ -159,9 +159,9 @@ internal class GlobalExceptionHandler {
     fun handleCreatingRiScException(ex: CreatingRiScException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenCreatingRiSc,
-            ex.message,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenCreatingRiSc,
+            statusMessage = ex.message,
         )
     }
 
@@ -171,9 +171,9 @@ internal class GlobalExceptionHandler {
     fun handleGenerateInitialRiScException(ex: GenerateInitialRiScException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            ex.riScId,
-            ProcessingStatus.ErrorWhenGeneratingInitialRiSc,
-            ex.message,
+            riScId = ex.riScId,
+            status = ProcessingStatus.ErrorWhenGeneratingInitialRiSc,
+            statusMessage = ex.message,
         )
     }
 
@@ -262,9 +262,9 @@ internal class GlobalExceptionHandler {
     fun handleFetchException(ex: FetchException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            "",
-            ex.status,
-            ex.status.message,
+            riScId = "",
+            status = ex.status,
+            statusMessage = ex.status.message,
         )
     }
 }

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -147,7 +147,7 @@ class GithubConnector(
                 responseMessage = "Could not fetch SOPS config",
             )
 
-            else -> GithubContentResponse(sopsConfig, GithubStatus.Success)
+            else -> GithubContentResponse(data = sopsConfig, status = GithubStatus.Success)
         }
     }
 
@@ -158,7 +158,7 @@ class GithubConnector(
     ): GithubContentResponse {
         val sopsConfig =
             getGithubResponse(
-                uri = githubHelper.uriToFindSopsConfig(repositoryOwner, repositoryName),
+                uri = githubHelper.uriToFindSopsConfig(owner = repositoryOwner, repository = repositoryName),
                 accessToken = githubAccessToken.value,
             ).bodyToMono<FileContentDTO>()
                 .block()
@@ -171,7 +171,7 @@ class GithubConnector(
                 responseMessage = "Could not fetch SOPS config",
             )
 
-            else -> GithubContentResponse(sopsConfig, GithubStatus.Success)
+            else -> GithubContentResponse(data = sopsConfig, status = GithubStatus.Success)
         }
     }
 
@@ -181,10 +181,30 @@ class GithubConnector(
         accessToken: String,
     ): GithubRiScIdentifiersResponse =
         coroutineScope {
-            val draftRiScsDeferred = async { fetchRiScIdentifiersDrafted(owner, repository, accessToken) }
-            val publishedRiScsDeferred = async { fetchPublishedRiScIdentifiers(owner, repository, accessToken) }
+            val draftRiScsDeferred =
+                async {
+                    fetchRiScIdentifiersDrafted(
+                        owner = owner,
+                        repository = repository,
+                        accessToken = accessToken,
+                    )
+                }
+            val publishedRiScsDeferred =
+                async {
+                    fetchPublishedRiScIdentifiers(
+                        owner = owner,
+                        repository = repository,
+                        accessToken = accessToken,
+                    )
+                }
             val riScsSentForApprovalDeferred =
-                async { fetchRiScIdentifiersSentForApproval(owner, repository, accessToken) }
+                async {
+                    fetchRiScIdentifiersSentForApproval(
+                        owner = owner,
+                        repository = repository,
+                        accessToken = accessToken,
+                    )
+                }
 
             val draftRiScs = draftRiScsDeferred.await()
             val publishedRiScs = publishedRiScsDeferred.await()
@@ -235,15 +255,15 @@ class GithubConnector(
         try {
             val fileContent =
                 getGithubResponseSuspend(
-                    githubHelper.uriToFindRiSc(owner, repository, id),
-                    accessToken,
+                    uri = githubHelper.uriToFindRiSc(owner = owner, repository = repository, id = id),
+                    accessToken = accessToken,
                 ).decodedFileContentSuspend()
             when (fileContent) {
-                null -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
-                else -> GithubContentResponse(fileContent, GithubStatus.Success)
+                null -> GithubContentResponse(data = null, status = GithubStatus.ContentIsEmpty)
+                else -> GithubContentResponse(data = fileContent, status = GithubStatus.Success)
             }
         } catch (e: Exception) {
-            GithubContentResponse(null, mapWebClientExceptionToGithubStatus(e))
+            GithubContentResponse(data = null, status = mapWebClientExceptionToGithubStatus(e))
         }
 
     suspend fun fetchDraftedRiScContent(
@@ -254,14 +274,16 @@ class GithubConnector(
     ): GithubContentResponse =
         try {
             val fileContent =
-                getGithubResponseSuspend(githubHelper.uriToFindRiScOnDraftBranch(owner, repository, id), accessToken)
-                    .decodedFileContentSuspend()
+                getGithubResponseSuspend(
+                    uri = githubHelper.uriToFindRiScOnDraftBranch(owner = owner, repository = repository, riScId = id),
+                    accessToken = accessToken,
+                ).decodedFileContentSuspend()
             when (fileContent) {
-                null -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
-                else -> GithubContentResponse(fileContent, GithubStatus.Success)
+                null -> GithubContentResponse(data = null, status = GithubStatus.ContentIsEmpty)
+                else -> GithubContentResponse(data = fileContent, status = GithubStatus.Success)
             }
         } catch (e: Exception) {
-            GithubContentResponse(null, mapWebClientExceptionToGithubStatus(e))
+            GithubContentResponse(data = null, status = mapWebClientExceptionToGithubStatus(e))
         }
 
     private suspend fun fetchPublishedRiScIdentifiers(
@@ -272,8 +294,8 @@ class GithubConnector(
         try {
             val response =
                 getGithubResponseSuspend(
-                    githubHelper.uriToFindRiScFiles(owner, repository),
-                    accessToken,
+                    uri = githubHelper.uriToFindRiScFiles(owner, repository),
+                    accessToken = accessToken,
                 ).awaitBody<List<FileNameDTO>>()
 
             response.riScIdentifiersPublished()
@@ -288,8 +310,10 @@ class GithubConnector(
     ): List<RiScIdentifier> =
         try {
             val response =
-                getGithubResponseSuspend(githubHelper.uriToFetchAllPullRequests(owner, repository), accessToken)
-                    .awaitBody<List<GithubPullRequestObject>>()
+                getGithubResponseSuspend(
+                    uri = githubHelper.uriToFetchAllPullRequests(owner = owner, repository = repository),
+                    accessToken = accessToken,
+                ).awaitBody<List<GithubPullRequestObject>>()
 
             response.riScIdentifiersSentForApproval()
         } catch (e: Exception) {
@@ -304,8 +328,8 @@ class GithubConnector(
         try {
             val response =
                 getGithubResponseSuspend(
-                    githubHelper.uriToFindAllRiScBranches(owner, repository),
-                    accessToken,
+                    uri = githubHelper.uriToFindAllRiScBranches(owner = owner, repository = repository),
+                    accessToken = accessToken,
                 ).awaitBody<List<GithubReferenceObjectDTO>>().map { it.toInternal() }
 
             response.riScIdentifiersDrafted()
@@ -325,17 +349,39 @@ class GithubConnector(
     ): RiScApprovalPRStatus {
         val accessToken = accessTokens.githubAccessToken.value
         // Attempt to get SHA for the existing draft
-        val latestShaForDraft = getSHAForExistingRiScDraftOrNull(owner, repository, riScId, accessToken)
+        val latestShaForDraft =
+            getSHAForExistingRiScDraftOrNull(
+                owner = owner,
+                repository = repository,
+                riScId = riScId,
+                accessToken = accessToken,
+            )
         var latestShaForPublished: String? = null
 
         // A new branch is needed if an existing branch was not found
         if (latestShaForDraft == null) {
             runBlocking {
-                val newBranchDeferred = async { createNewBranch(owner, repository, riScId, accessToken, defaultBranch) }
+                val newBranchDeferred =
+                    async {
+                        createNewBranch(
+                            owner = owner,
+                            repository = repository,
+                            newBranchName = riScId,
+                            accessToken = accessToken,
+                            defaultBranch = defaultBranch,
+                        )
+                    }
 
                 // Determine if the change is an update or create request
                 latestShaForPublished =
-                    async { getSHAForPublishedRiScOrNull(owner, repository, riScId, accessToken) }.await()
+                    async {
+                        getSHAForPublishedRiScOrNull(
+                            owner = owner,
+                            repository = repository,
+                            riScId = riScId,
+                            accessToken = accessToken,
+                        )
+                    }.await()
 
                 newBranchDeferred.await()
             }
@@ -350,18 +396,26 @@ class GithubConnector(
             }
 
         putFileRequestToGithub(
-            owner,
-            repository,
-            accessTokens.githubAccessToken,
-            "$riScFolderPath/$riScId.$filenamePostfix.yaml",
-            riScId,
-            commitMessage,
-            fileContent.encodeBase64(),
+            repositoryOwner = owner,
+            repositoryName = repository,
+            gitHubAccessToken = accessTokens.githubAccessToken,
+            filePath = "$riScFolderPath/$riScId.$filenamePostfix.yaml",
+            branch = riScId,
+            message = commitMessage,
+            content = fileContent.encodeBase64(),
         ).bodyToMono<String>().block()
 
         val riScApprovalPRStatus =
             runBlocking {
-                val prExistsDeferred = async { pullRequestForRiScExists(owner, repository, riScId, accessToken) }
+                val prExistsDeferred =
+                    async {
+                        pullRequestForRiScExists(
+                            owner = owner,
+                            repository = repository,
+                            riScId = riScId,
+                            accessToken = accessToken,
+                        )
+                    }
 
                 val commitsAheadOfDefaultRequiresApprovalDeferred =
                     async {
@@ -379,11 +433,11 @@ class GithubConnector(
                         latestCommitTimestamp
                             ?.let { it ->
                                 fetchCommitsSinceLastCommit(
-                                    owner,
-                                    repository,
-                                    accessToken,
-                                    riScId,
-                                    it,
+                                    owner = owner,
+                                    repository = repository,
+                                    accessToken = accessToken,
+                                    riScId = riScId,
+                                    since = it,
                                 ).filterNot { it.commit.committer.date == latestCommitTimestamp }
                             }?.any { it.commit.message.contains("requires new approval") } ?: true
                     }
@@ -408,12 +462,17 @@ class GithubConnector(
                             userInfo = userInfo,
                             baseBranch = defaultBranch,
                         )
-                    RiScApprovalPRStatus(pullRequest, false)
+                    RiScApprovalPRStatus(pullRequest = pullRequest, hasClosedPr = false)
                 } else if (requiresNewApproval && prExists) {
-                    closePullRequestForRiSc(owner, repository, riScId, accessToken)
-                    RiScApprovalPRStatus(null, true)
+                    closePullRequestForRiSc(
+                        owner = owner,
+                        repository = repository,
+                        riScId = riScId,
+                        accessToken = accessToken,
+                    )
+                    RiScApprovalPRStatus(pullRequest = null, hasClosedPr = true)
                 } else {
-                    RiScApprovalPRStatus(null, false)
+                    RiScApprovalPRStatus(pullRequest = null, hasClosedPr = false)
                 }
             }
         return riScApprovalPRStatus
@@ -428,7 +487,12 @@ class GithubConnector(
         fetchAllPullRequests(owner, repository, accessToken).find { it.head.ref == riScId }?.let {
             try {
                 closePullRequest(
-                    uri = githubHelper.uriToEditPullRequest(owner, repository, it.number),
+                    uri =
+                        githubHelper.uriToEditPullRequest(
+                            owner = owner,
+                            repository = repository,
+                            pullRequestNumber = it.number,
+                        ),
                     accessToken = accessToken,
                     closePullRequestBody = githubHelper.bodyToClosePullRequest(),
                 ).bodyToMono<String>().block()
@@ -444,8 +508,15 @@ class GithubConnector(
         riScId: String,
         accessToken: String,
     ) = try {
-        getGithubResponse(githubHelper.uriToFindRiScOnDraftBranch(owner, repository, riScId), accessToken)
-            .shaResponseDTO()
+        getGithubResponse(
+            uri =
+                githubHelper.uriToFindRiScOnDraftBranch(
+                    owner = owner,
+                    repository = repository,
+                    riScId = riScId,
+                ),
+            accessToken = accessToken,
+        ).shaResponseDTO()
     } catch (e: Exception) {
         null
     }
@@ -456,8 +527,15 @@ class GithubConnector(
         riScId: String,
         accessToken: String,
     ) = try {
-        getGithubResponse(githubHelper.uriToFindRiSc(owner, repository, riScId), accessToken)
-            .shaResponseDTO()
+        getGithubResponse(
+            uri =
+                githubHelper.uriToFindRiSc(
+                    owner = owner,
+                    repository = repository,
+                    id = riScId,
+                ),
+            accessToken = accessToken,
+        ).shaResponseDTO()
     } catch (e: Exception) {
         null
     }
@@ -467,7 +545,12 @@ class GithubConnector(
         repository: String,
         riScId: String,
         accessToken: String,
-    ): Boolean = fetchRiScIdentifiersSentForApproval(owner, repository, accessToken).any { it.id == riScId }
+    ): Boolean =
+        fetchRiScIdentifiersSentForApproval(
+            owner = owner,
+            repository = repository,
+            accessToken = accessToken,
+        ).any { it.id == riScId }
 
     private fun fetchLatestShaForDefaultBranch(
         owner: String,
@@ -476,8 +559,13 @@ class GithubConnector(
         defaultBranch: String,
     ): String? =
         getGithubResponse(
-            githubHelper.uriToGetCommitStatus(owner, repository, defaultBranch),
-            accessToken,
+            uri =
+                githubHelper.uriToGetCommitStatus(
+                    owner = owner,
+                    repository = repository,
+                    branchName = defaultBranch,
+                ),
+            accessToken = accessToken,
         ).shaResponseDTO()
 
     fun createNewBranch(
@@ -488,9 +576,15 @@ class GithubConnector(
         defaultBranch: String,
     ): String? {
         val latestShaForDefaultBranch =
-            fetchLatestShaForDefaultBranch(owner, repository, accessToken, defaultBranch) ?: return null
+            fetchLatestShaForDefaultBranch(
+                owner = owner,
+                repository = repository,
+                accessToken = accessToken,
+                defaultBranch = defaultBranch,
+            )
+                ?: return null
         return postNewBranchToGithub(
-            uri = githubHelper.uriToCreateNewBranchForRiSc(owner, repository),
+            uri = githubHelper.uriToCreateNewBranchForRiSc(owner = owner, repository = repository),
             accessToken = accessToken,
             branchPayload =
                 githubHelper.bodyToCreateNewBranchFromDefault(
@@ -506,8 +600,10 @@ class GithubConnector(
         accessToken: String,
     ): List<GithubPullRequestObject> =
         try {
-            getGithubResponse(githubHelper.uriToFetchAllPullRequests(owner, repository), accessToken)
-                .toPullRequestResponseDTOs()
+            getGithubResponse(
+                uri = githubHelper.uriToFetchAllPullRequests(owner = owner, repository = repository),
+                accessToken = accessToken,
+            ).toPullRequestResponseDTOs()
         } catch (e: Exception) {
             emptyList()
         }
@@ -568,7 +664,7 @@ class GithubConnector(
     ): GithubPullRequestObject? =
         try {
             postNewPullRequestToGithub(
-                uri = githubHelper.uriToCreatePullRequest(owner, repository),
+                uri = githubHelper.uriToCreatePullRequest(owner = owner, repository = repository),
                 accessToken = accessTokens.githubAccessToken.value,
                 pullRequestPayload =
                     githubHelper.bodyToCreateNewPullRequest(
@@ -700,16 +796,21 @@ class GithubConnector(
         branch: String,
     ): String =
         putFileRequestToGithub(
-            repositoryOwner,
-            repositoryName,
-            gitHubAccessToken,
-            "$riScFolderPath/.sops.yaml",
-            branch,
-            "Update SOPS configuration",
-            sopsConfig.encodeBase64(),
+            repositoryOwner = repositoryOwner,
+            repositoryName = repositoryName,
+            gitHubAccessToken = gitHubAccessToken,
+            filePath = "$riScFolderPath/.sops.yaml",
+            branch = branch,
+            message = "Update SOPS configuration",
+            content = sopsConfig.encodeBase64(),
         ).bodyToMono<String>().block() ?: throw UnableToWriteSopsConfigException(
-            "Failed to put new sops config on branch: '$branch'",
-            ProcessRiScResultDTO("", ProcessingStatus.FailedToCreateSops, ProcessingStatus.FailedToCreateSops.message),
+            message = "Failed to put new sops config on branch: '$branch'",
+            response =
+                ProcessRiScResultDTO(
+                    riScId = "",
+                    status = ProcessingStatus.FailedToCreateSops,
+                    statusMessage = ProcessingStatus.FailedToCreateSops.message,
+                ),
         )
 
     private fun fetchFileInfo(
@@ -720,15 +821,22 @@ class GithubConnector(
         branch: String,
     ) = try {
         getGithubResponse(
-            githubHelper.repositoryContentsUri(repositoryOwner, repositoryName, filePath, branch),
-            gitHubAccessToken.value,
+            uri =
+                githubHelper.repositoryContentsUri(
+                    owner = repositoryOwner,
+                    repository = repositoryName,
+                    path = filePath,
+                    branch = branch,
+                ),
+            accessToken = gitHubAccessToken.value,
         ).toFileContentDTO() ?: throw GitHubFetchException(
-            "Unable to parse file information for file $filePath on $repositoryOwner/$repositoryName on branch: $branch",
-            ProcessRiScResultDTO(
-                "",
-                ProcessingStatus.FailedToCreateSops,
-                ProcessingStatus.FailedToCreateSops.message,
-            ),
+            message = "Unable to parse file information for file $filePath on $repositoryOwner/$repositoryName on branch: $branch",
+            response =
+                ProcessRiScResultDTO(
+                    riScId = "",
+                    status = ProcessingStatus.FailedToCreateSops,
+                    statusMessage = ProcessingStatus.FailedToCreateSops.message,
+                ),
         )
     } catch (e: WebClientResponseException.NotFound) {
         null
@@ -857,8 +965,8 @@ class GithubConnector(
     ): RepositoryInfo {
         val repositoryDTO =
             fetchRepositoryInfo(
-                githubHelper.uriToGetRepositoryInfo(repositoryOwner, repositoryName),
-                gitHubAccessToken,
+                uri = githubHelper.uriToGetRepositoryInfo(owner = repositoryOwner, repository = repositoryName),
+                gitHubAccessToken = gitHubAccessToken,
             )
         if (repositoryDTO.permissions.pull) {
             if (repositoryDTO.permissions.push) {
@@ -918,18 +1026,15 @@ class GithubConnector(
             uri = githubHelper.uriToFetchAllPullRequests(owner = repositoryOwner, repository = repositoryName),
             accessToken = gitHubAccessToken.value,
         ).toPullRequestResponseDTOs()
-            .filter {
-                it.head.ref in branches &&
-                    it.base.ref == defaultBranch
-            }
+            .filter { it.head.ref in branches && it.base.ref == defaultBranch }
 
     fun fetchAllBranches(
         repositoryOwner: String,
         repositoryName: String,
         gitHubAccessToken: GithubAccessToken,
     ) = getGithubResponse(
-        githubHelper.uriToFindAllBranches(owner = repositoryOwner, repository = repositoryName),
-        gitHubAccessToken.value,
+        uri = githubHelper.uriToFindAllBranches(owner = repositoryOwner, repository = repositoryName),
+        accessToken = gitHubAccessToken.value,
     ).toRepositoryBranchDTO()
 
     fun fetchAllRiScsOnDefaultBranch(
@@ -940,8 +1045,8 @@ class GithubConnector(
         val fileContentPaths =
             try {
                 getGithubResponse(
-                    githubHelper.uriToFindRiScFiles(owner = repositoryOwner, repository = repositoryName),
-                    gitHubAccessToken.value,
+                    uri = githubHelper.uriToFindRiScFiles(owner = repositoryOwner, repository = repositoryName),
+                    accessToken = gitHubAccessToken.value,
                 ).toFileContentsDTO() ?: throw GitHubFetchException(
                     "Unable to fetch RiScs file paths on default branch for $repositoryOwner/$repositoryName",
                     ProcessRiScResultDTO(

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -79,7 +79,13 @@ data class GithubPullRequestObject(
     val number: Int,
     val user: GitHubPullRequestUser,
 ) {
-    fun toPullRequestObject() = PullRequestObject(url, title, user.login, createdAt)
+    fun toPullRequestObject() =
+        PullRequestObject(
+            url = url,
+            title = title,
+            openedBy = user.login,
+            createdAt = createdAt,
+        )
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/no/risc/google/GoogleControllerIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleControllerIntegration.kt
@@ -24,6 +24,6 @@ class GoogleControllerIntegration(
         @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String? = null,
     ): List<GcpCryptoKeyObject> {
         LOGGER.info("Fetching GCP crypto keys")
-        return googleServiceIntegration.getGcpCryptoKeys(GCPAccessToken(gcpAccessToken))
+        return googleServiceIntegration.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken(gcpAccessToken))
     }
 }

--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -139,18 +139,18 @@ class GoogleServiceIntegration(
                     it to
                         async(Dispatchers.IO) {
                             testIamPermissions(
-                                it.getRiScCryptoKeyResourceId(),
-                                gcpAccessToken,
-                                GcpIamPermission.ENCRYPT_DECRYPT,
+                                cryptoKeyResourceId = it.getRiScCryptoKeyResourceId(),
+                                gcpAccessToken = gcpAccessToken,
+                                permissions = GcpIamPermission.ENCRYPT_DECRYPT,
                             )
                         }
                 }.map { (gcpProjectId, hasAccess) ->
                     GcpCryptoKeyObject(
-                        gcpProjectId.value,
-                        gcpProjectId.getRiScKeyRing(),
-                        gcpProjectId.getRiScCryptoKey(),
-                        gcpProjectId.getRiScCryptoKeyResourceId(),
-                        hasAccess.await(),
+                        projectId = gcpProjectId.value,
+                        keyRing = gcpProjectId.getRiScKeyRing(),
+                        name = gcpProjectId.getRiScCryptoKey(),
+                        resourceId = gcpProjectId.getRiScCryptoKeyResourceId(),
+                        hasEncryptDecryptAccess = hasAccess.await(),
                     )
                 }.toMutableList()
         }

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -29,7 +29,11 @@ class InitRiScServiceIntegration(
             .bodyToMono<String>()
             .block() ?: throw SopsConfigGenerateFetchException(
             "Failed to generate default RiSc",
-            ProcessRiScResultDTO("", ProcessingStatus.ErrorWhenCreatingRiSc, ProcessingStatus.ErrorWhenCreatingRiSc.message),
+            ProcessRiScResultDTO(
+                riScId = "",
+                status = ProcessingStatus.ErrorWhenCreatingRiSc,
+                statusMessage = ProcessingStatus.ErrorWhenCreatingRiSc.message,
+            ),
         )
 
     fun generateSopsConfig(
@@ -42,18 +46,23 @@ class InitRiScServiceIntegration(
             .body(
                 BodyInserters.fromValue(
                     GenerateSopsConfigRequestBody(
-                        GenerateSopsConfigGcpCryptoKeyObject(
-                            gcpCryptoKey.projectId,
-                            gcpCryptoKey.keyRing,
-                            gcpCryptoKey.name,
-                        ),
-                        publicAgeKeys,
+                        gcpCryptoKey =
+                            GenerateSopsConfigGcpCryptoKeyObject(
+                                projectId = gcpCryptoKey.projectId,
+                                keyRing = gcpCryptoKey.keyRing,
+                                name = gcpCryptoKey.name,
+                            ),
+                        publicAgeKeys = publicAgeKeys,
                     ),
                 ),
             ).retrieve()
             .bodyToMono<String>()
             .block() ?: throw SopsConfigGenerateFetchException(
             "Failed to generate sops config by calling init risc service",
-            ProcessRiScResultDTO("", ProcessingStatus.FailedToCreateSops, ProcessingStatus.FailedToCreateSops.message),
+            ProcessRiScResultDTO(
+                riScId = "",
+                status = ProcessingStatus.FailedToCreateSops,
+                statusMessage = ProcessingStatus.FailedToCreateSops.message,
+            ),
         )
 }

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -239,7 +239,7 @@ class RiScService(
                     } catch (e: DifferenceException) {
                         InternDifference(
                             status = DifferenceStatus.JsonFailure,
-                            Difference(),
+                            differenceState = Difference(),
                             errorMessage = "${e.message}",
                         )
                     }

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -29,11 +29,11 @@ class AccessTokenValidationFilter(
                     )
 
                 validationService.validateAccessTokens(
-                    request.getHeader("GCP-Access-Token"),
-                    request.getHeader("GitHub-Access-Token"),
-                    GitHubPermission.WRITE,
-                    repository.repositoryOwner,
-                    repository.repositoryName,
+                    gcpAccessToken = request.getHeader("GCP-Access-Token"),
+                    gitHubAccessToken = request.getHeader("GitHub-Access-Token"),
+                    gitHubPermissionNeeded = GitHubPermission.WRITE,
+                    repositoryOwner = repository.repositoryOwner,
+                    repositoryName = repository.repositoryName,
                 )
             }
             filterChain.doFilter(request, response)

--- a/src/main/kotlin/no/risc/sops/SopsController.kt
+++ b/src/main/kotlin/no/risc/sops/SopsController.kt
@@ -36,11 +36,11 @@ class SopsController(
         val validationResult = Validator.validate(requestBody)
         return if (validationResult.isValid) {
             sopsService.createSopsConfig(
-                repositoryOwner,
-                repositoryName,
-                requestBody.gcpCryptoKey,
-                requestBody.publicAgeKeys,
-                AccessTokens(GithubAccessToken(gitHubAccessToken), GCPAccessToken(gcpAccessToken)),
+                repositoryOwner = repositoryOwner,
+                repositoryName = repositoryName,
+                gcpCryptoKey = requestBody.gcpCryptoKey,
+                publicAgeKeys = requestBody.publicAgeKeys,
+                accessTokens = AccessTokens(GithubAccessToken(gitHubAccessToken), GCPAccessToken(gcpAccessToken)),
             )
         } else {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, validationResult.message)
@@ -59,12 +59,12 @@ class SopsController(
         val validationResult = Validator.validate(requestBody)
         return if (validationResult.isValid) {
             sopsService.updateSopsConfig(
-                repositoryOwner,
-                repositoryName,
-                ref,
-                requestBody.gcpCryptoKey,
-                requestBody.publicAgeKeys,
-                AccessTokens(GithubAccessToken(gitHubAccessToken), GCPAccessToken(gcpAccessToken)),
+                repositoryOwner = repositoryOwner,
+                repositoryName = repositoryName,
+                branch = ref,
+                gcpCryptoKey = requestBody.gcpCryptoKey,
+                publicAgeKeys = requestBody.publicAgeKeys,
+                accessTokens = AccessTokens(GithubAccessToken(gitHubAccessToken), GCPAccessToken(gcpAccessToken)),
             )
         } else {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, validationResult.message)
@@ -79,9 +79,13 @@ class SopsController(
         @PathVariable("repositoryName") repositoryName: String,
         @PathVariable("branch") branch: String,
     ) = sopsService.openPullRequest(
-        repositoryOwner,
-        repositoryName,
-        branch,
-        AccessTokens(GithubAccessToken(gitHubAccessToken), GCPAccessToken(gcpAccessToken)).githubAccessToken,
+        repositoryOwner = repositoryOwner,
+        repositoryName = repositoryName,
+        sopsId = branch,
+        githubAccessToken =
+            AccessTokens(
+                githubAccessToken = GithubAccessToken(gitHubAccessToken),
+                gcpAccessToken = GCPAccessToken(gcpAccessToken),
+            ).githubAccessToken,
     )
 }

--- a/src/main/kotlin/no/risc/sops/SopsService.kt
+++ b/src/main/kotlin/no/risc/sops/SopsService.kt
@@ -72,17 +72,25 @@ class SopsService(
         accessTokens: AccessTokens,
     ): CreateSopsConfigResponseBody {
         val defaultBranch =
-            githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, accessTokens.githubAccessToken.value)
+            githubConnector.fetchDefaultBranch(
+                repositoryOwner = repositoryOwner,
+                repositoryName = repositoryName,
+                gitHubAccessToken = accessTokens.githubAccessToken.value,
+            )
         LOGGER.info("Generating SOPS config for $repositoryOwner/$repositoryName")
-        val newSopsConfig = initRiScServiceIntegration.generateSopsConfig(gcpCryptoKey, publicAgeKeys)
+        val newSopsConfig =
+            initRiScServiceIntegration.generateSopsConfig(
+                gcpCryptoKey = gcpCryptoKey,
+                publicAgeKeys = publicAgeKeys,
+            )
         LOGGER.info("Generated SOPS config for $repositoryOwner/$repositoryName")
         val branch = generateSopsId()
         githubConnector.createNewBranch(
-            repositoryOwner,
-            repositoryName,
-            branch,
-            accessTokens.githubAccessToken.value,
-            defaultBranch,
+            owner = repositoryOwner,
+            repository = repositoryName,
+            newBranchName = branch,
+            accessToken = accessTokens.githubAccessToken.value,
+            defaultBranch = defaultBranch,
         ) ?: throw CreateNewBranchException(
             "Unable to create new branch for generate SOPS config",
             response =
@@ -95,11 +103,11 @@ class SopsService(
 
         LOGGER.info("Writing SOPS config github.com/$repositoryOwner/$repositoryName")
         githubConnector.writeSopsConfig(
-            newSopsConfig,
-            repositoryOwner,
-            repositoryName,
-            accessTokens.githubAccessToken,
-            branch,
+            sopsConfig = newSopsConfig,
+            repositoryOwner = repositoryOwner,
+            repositoryName = repositoryName,
+            gitHubAccessToken = accessTokens.githubAccessToken,
+            branch = branch,
         )
 
         // TODO: This will be the block needed to re-encrypt existing RiSc on default branch with the newly generated SOPS configuration
@@ -139,8 +147,8 @@ class SopsService(
             ProcessingStatus.CreatedSops,
             ProcessingStatus.CreatedSops.message,
             SopsConfigDTO(
-                gcpCryptoKey,
-                publicAgeKeys,
+                gcpCryptoKey = gcpCryptoKey,
+                publicAgeKeys = publicAgeKeys,
             ),
         )
     }
@@ -155,15 +163,15 @@ class SopsService(
     ): UpdateSopsConfigResponseBody {
         val newSopsConfig = initRiScServiceIntegration.generateSopsConfig(gcpCryptoKey, publicAgeKeys)
         githubConnector.writeSopsConfig(
-            newSopsConfig,
-            repositoryOwner,
-            repositoryName,
-            accessTokens.githubAccessToken,
-            branch,
+            sopsConfig = newSopsConfig,
+            repositoryOwner = repositoryOwner,
+            repositoryName = repositoryName,
+            gitHubAccessToken = accessTokens.githubAccessToken,
+            branch = branch,
         )
         return UpdateSopsConfigResponseBody(
-            ProcessingStatus.UpdatedSops,
-            ProcessingStatus.UpdatedSops.message,
+            status = ProcessingStatus.UpdatedSops,
+            statusMessage = ProcessingStatus.UpdatedSops.message,
         )
     }
 
@@ -173,27 +181,32 @@ class SopsService(
         sopsId: String,
         githubAccessToken: GithubAccessToken,
     ): OpenPullRequestForSopsConfigResponseBody {
-        val defaultBranch = githubConnector.fetchDefaultBranch(repositoryOwner, repositoryName, githubAccessToken.value)
+        val defaultBranch =
+            githubConnector.fetchDefaultBranch(
+                repositoryOwner = repositoryOwner,
+                repositoryName = repositoryName,
+                gitHubAccessToken = githubAccessToken.value,
+            )
         val pullRequestObject =
             githubConnector
                 .createPullRequestForSopsConfig(
-                    repositoryOwner,
-                    repositoryName,
-                    sopsId,
-                    githubAccessToken,
-                    defaultBranch,
+                    owner = repositoryOwner,
+                    repository = repositoryName,
+                    sopsId = sopsId,
+                    gitHubAccessToken = githubAccessToken,
+                    defaultBranch = defaultBranch,
                 )?.toPullRequestObject() ?: throw GitHubFetchException(
                 "Unable to create pull request for sops config with branch: $sopsId",
                 ProcessRiScResultDTO(
-                    "",
-                    ProcessingStatus.ErrorWhenCreatingPullRequest,
-                    ProcessingStatus.ErrorWhenCreatingPullRequest.message,
+                    riScId = "",
+                    status = ProcessingStatus.ErrorWhenCreatingPullRequest,
+                    statusMessage = ProcessingStatus.ErrorWhenCreatingPullRequest.message,
                 ),
             )
         return OpenPullRequestForSopsConfigResponseBody(
-            ProcessingStatus.OpenedPullRequest,
-            ProcessingStatus.OpenedPullRequest.message,
-            pullRequestObject,
+            status = ProcessingStatus.OpenedPullRequest,
+            statusMessage = ProcessingStatus.OpenedPullRequest.message,
+            pullRequest = pullRequestObject,
         )
     }
 }

--- a/src/main/kotlin/no/risc/validation/JSONValidator.kt
+++ b/src/main/kotlin/no/risc/validation/JSONValidator.kt
@@ -14,8 +14,7 @@ import org.slf4j.LoggerFactory
 enum class SchemaVersion {
     VERSION_3_2,
     VERSION_3_3,
-    VERSION_4_0,
-    ;
+    VERSION_4_0, ;
 
     fun toExpectedString() =
         when (this) {


### PR DESCRIPTION
Closes #335

Named args are easier to read.
Also not susceptible to reordering of args in the function definition