### PR TITLE
Fix Pharos workflow on draft

### DIFF
--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Run Pharos"
-        uses: kartverket/pharos@v0.2.3
+        uses: kartverket/pharos@v0.3.1
         with:
           image_url: ${{ needs.build.outputs.image_url }}
 

--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -127,6 +127,7 @@ jobs:
 
   pharos:
     name: Run Pharos on docker image
+    if: ${{ !github.event.pull_request.draft }}
     needs: build
     permissions:
       actions: read

--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: boolean
   pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     branches:
       - main
     paths:


### PR DESCRIPTION
Fixes an issue in which the Pharos workflow would crash for draft PRs as draft PRs are configured to not push Docker containers in the build stage. This PR turns the Pharos workflow off for draft PRs, but runs the Pharos workflow automatically when the PR is marked as `ready for review`.

Also bumps the version of Pharos to 0.3.1, the newest version available.