### PR TITLE
Fix code scanning security warnings

### DIFF
--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -148,6 +148,8 @@ jobs:
         uses: kartverket/pharos@v0.3.1
         with:
           image_url: ${{ needs.build.outputs.image_url }}
+          # Backstage config files are misclassified as kubernetes config files, resulting in false security issues
+          skip_dirs: '.security/.backstage/component,.security/.backstage/system'
 
   dev-deploy-argo:
     name: Deploy to atgcp1-dev

--- a/backstage-plugin-risk-scorecard-backend.yaml
+++ b/backstage-plugin-risk-scorecard-backend.yaml
@@ -60,6 +60,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 512Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
       volumes:
         - name: sops-age-key
           secret:


### PR DESCRIPTION
Attempts to fix code scanning alerts related to Kubernetes:
- [#249](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/code-scanning/249) – Can elevate its own privileges
- [#251](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/code-scanning/251) – Runs as root user
- [#253](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/code-scanning/253) – Root file system is not read-only

Also adds some backstage config files as ignored, as they are misclassified as Kubernetes files and therefore produce incorrect security scanning alerts. As far as I can tell, Trivy do not support backstage config files anyhow. Some of these files are not ignored, due to missing argument options in Pharos. See #365 for details.