### PR TITLE
Fjerner filtering av kun prod-prosjekter

### DIFF
--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -134,7 +134,6 @@ class GoogleServiceIntegration(
                         ProcessingStatus.FailedToFetchGcpProjectIds,
                     )
             gcpProjectIds
-                .filter { it.value.contains("-prod-") }
                 .map {
                     it to
                         async(Dispatchers.IO) {


### PR DESCRIPTION
I spire-riggen har vi ikke post-fixen: "prod" slik som GCP-prosjektene i Kartverket har. Klarer derfor ikke å hente ut GCP-nøkler når vi lager ny RoS. Fjerner derfor filtering av nøkkelordet "prod" når backend søker etter nøkler.