### PR TITLE
Bump KotlinXSerialization to 1.8.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ repositories {
 val kotlinVersion = "2.1.20"
 val springBootVersion = "3.4.4"
 val springSecurityVersion = "6.4.4"
-val kotlinxSerializationVersion = "1.8.0"
+val kotlinxSerializationVersion = "1.8.1"
 val kotlinxCoroutinesVersion = "1.10.1"
 val nettyVersion = "4.1.119.Final"
 val micrometerVersion = "1.14.5"
@@ -65,6 +65,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinxCoroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$kotlinxSerializationVersion")
 
     implementation("io.netty:netty-all:$nettyVersion")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("org.springframework.boot") version "3.4.4"
-    id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version "2.1.20"
     kotlin("plugin.spring") version "2.1.20"
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
@@ -65,7 +64,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinxCoroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$kotlinxSerializationVersion")
 
     implementation("io.netty:netty-all:$nettyVersion")
 


### PR DESCRIPTION
Upgrade KotlinXSerialization to 1.8.1 (latest). 

Includes `kotlinx-serialization-json-jvm` as a dependency with the same version as other kotlinx-serialization packages to force Gradle to actually use the specified versions. Without specifying `kotlinx-serialization-json-jvm`, the version used would be 1.6.3, rather than 1.8.1. This occurs even though the `kotlinx-serialization` packages are not subdependencies (on any level) of any other dependency of this project.

`kotlinx-serialization-json-jvm` is a direct dependency of `kotlinx-serialization-json`. 


Closes #368