### PR TITLE
Reduce requests by filtering keys

### DIFF
--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -134,6 +134,7 @@ class GoogleServiceIntegration(
                         ProcessingStatus.FailedToFetchGcpProjectIds,
                     )
             gcpProjectIds
+                .filter { it.value.contains("-prod-") }
                 .map {
                     it to
                         async(Dispatchers.IO) {


### PR DESCRIPTION
In [#366](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/pull/366), we removed filtering of the 'prod' keyword when searching for GCP keys, allowing all Spire keys to be retrieved.

However, this has led to 429 TOO_MANY_REQUESTS errors from POST https://cloudkms.googleapis.com on the Kartverket Platform. We need to implement a different approach to avoid overwhelming the API.