### PR TITLE
Cleanup and testing of crypto service integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ val nimbusdsVersion = "10.1"
 val bouncyCastleVersion = "1.80"
 val jsonWebTokenVersion = "0.12.6"
 val ninjaSquadVersion = "4.0.2"
+val mockkVersion = "1.13.17"
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
@@ -86,6 +87,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
     testImplementation("com.ninja-squad:springmockk:$ninjaSquadVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -1,5 +1,6 @@
 package no.risc.encryption
 
+import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.infra.connector.CryptoServiceConnector
 import no.risc.infra.connector.models.GCPAccessToken
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.awaitBody
+import kotlin.math.min
 
 data class EncryptionRequest(
     val text: String,
@@ -26,64 +28,65 @@ class CryptoServiceIntegration(
         val LOGGER: Logger = LoggerFactory.getLogger(CryptoServiceIntegration::class.java)
     }
 
-    fun encrypt(
+    suspend fun encrypt(
         text: String,
         sopsConfig: SopsConfig,
         gcpAccessToken: GCPAccessToken,
         riScId: String,
-    ): String {
-        val encryptionRequest =
-            EncryptionRequest(
-                text = text,
-                config = sopsConfig,
-                gcpAccessToken = gcpAccessToken.value,
-                riScId = riScId,
-            )
-
-        return try {
+    ): String =
+        try {
+            LOGGER.info("Trying to encrypt text: ${text.substring(0, min(text.length, 20))}...")
             cryptoServiceConnector.webClient
                 .post()
                 .uri("/encrypt")
-                .body(BodyInserters.fromValue(encryptionRequest))
-                .retrieve()
-                .bodyToMono(String::class.java)
-                .block()
-                ?.toString() ?: throw SopsEncryptionException(
-                message = "Failed to encrypt file",
+                .body(
+                    BodyInserters.fromValue(
+                        EncryptionRequest(
+                            text = text,
+                            config = sopsConfig,
+                            gcpAccessToken = gcpAccessToken.value,
+                            riScId = riScId,
+                        ),
+                    ),
+                ).retrieve()
+                .awaitBody<String>()
+                .also {
+                    LOGGER.info(
+                        "Successfully encrypted text ${text.substring(0, min(text.length, 20))}..." +
+                            "to ${it.substring(0, min(it.length, 20))}...",
+                    )
+                }
+        } catch (e: NoSuchElementException) {
+            throw SopsEncryptionException(
+                message = "Failed to encrypt RiSc, no response body received from encryption service.",
                 riScId = riScId,
             )
         } catch (e: Exception) {
-            throw SopsEncryptionException(
-                message = e.stackTraceToString(),
-                riScId = riScId,
-            )
+            throw SopsEncryptionException(message = e.stackTraceToString(), riScId = riScId)
         }
-    }
 
     suspend fun decrypt(
         ciphertext: String,
         gcpAccessToken: GCPAccessToken,
     ): RiScWithConfig =
         try {
-            LOGGER.info("Trying to decrypt ciphertext: ${ciphertext.substring(0, 14)}")
-            val decryptedFileWithConfig =
-                cryptoServiceConnector.webClient
-                    .post()
-                    .uri("/decrypt")
-                    .header("gcpAccessToken", gcpAccessToken.value)
-                    .bodyValue(ciphertext)
-                    .retrieve()
-                    .awaitBody<RiScWithConfig>()
-            LOGGER.info(
-                "Successfully decrypted ciphertext ${
-                    ciphertext.substring(
-                        0,
-                        20,
+            LOGGER.info("Trying to decrypt ciphertext: ${ciphertext.substring(0, min(ciphertext.length, 20))}...")
+            cryptoServiceConnector.webClient
+                .post()
+                .uri("/decrypt")
+                .header("gcpAccessToken", gcpAccessToken.value)
+                .bodyValue(ciphertext)
+                .retrieve()
+                .awaitBody<RiScWithConfig>()
+                .also {
+                    LOGGER.info(
+                        "Successfully decrypted ciphertext ${ciphertext.substring(0, min(ciphertext.length, 20))}..." +
+                            "to ${it.riSc.substring(0, min(it.riSc.length, 20))}...",
                     )
-                } to ${decryptedFileWithConfig.riSc.substring(0, 20)}",
-            )
-            decryptedFileWithConfig
+                }
+        } catch (_: NoSuchElementException) {
+            throw SOPSDecryptionException(message = "Failed to decrypt ciphertext, no response body received from decryption service.")
         } catch (e: Exception) {
-            throw e
+            throw SOPSDecryptionException(message = e.stackTraceToString())
         }
 }

--- a/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiScWithConfig.kt
@@ -1,7 +1,9 @@
 package no.risc.risc.models
 
+import kotlinx.serialization.Serializable
 import no.risc.sops.model.SopsConfig
 
+@Serializable
 data class RiScWithConfig(
     val riSc: String,
     val sopsConfig: SopsConfig,

--- a/src/test/kotlin/WebClientUtil.kt
+++ b/src/test/kotlin/WebClientUtil.kt
@@ -1,0 +1,54 @@
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+data class MockableResponse(
+    val content: String,
+    val contentType: MediaType = MediaType.APPLICATION_JSON,
+    val httpStatus: HttpStatus = HttpStatus.OK,
+)
+
+inline fun <reified T> mockableResponseFromObject(obj: T): MockableResponse = MockableResponse(content = Json.encodeToString<T>(obj))
+
+data class MockableRequest(
+    val content: String,
+    val headers: Map<String, List<String>>,
+)
+
+class MockableWebClient {
+    private val responses = mutableListOf<MockableResponse>()
+    private val requests = mutableListOf<MockableRequest>()
+    val webClient: WebClient =
+        WebClient
+            .builder()
+            .exchangeFunction { handleRequest(it) }
+            .build()
+
+    private fun handleRequest(request: ClientRequest): Mono<ClientResponse> {
+        requests.add(
+            MockableRequest(
+                content = request.body().toString(),
+                headers = request.headers().toMap(),
+            ),
+        )
+
+        if (responses.isEmpty()) return Mono.empty()
+        val response = responses.removeFirst()
+        return Mono.just(
+            ClientResponse
+                .create(HttpStatus.OK)
+                .header("content-type", response.contentType.toString())
+                .body(response.content)
+                .build(),
+        )
+    }
+
+    fun queueResponse(response: MockableResponse) = responses.add(response)
+
+    fun getNextRequest(): MockableRequest = requests.removeFirst()
+}

--- a/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
@@ -1,0 +1,133 @@
+package no.risc.encryption
+
+import MockableResponse
+import MockableWebClient
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import mockableResponseFromObject
+import no.risc.exception.exceptions.SOPSDecryptionException
+import no.risc.exception.exceptions.SopsEncryptionException
+import no.risc.infra.connector.CryptoServiceConnector
+import no.risc.infra.connector.models.GCPAccessToken
+import no.risc.risc.models.RiScWithConfig
+import no.risc.sops.model.GcpKmsEntry
+import no.risc.sops.model.SopsConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
+
+class CryptoServiceIntegrationTests {
+    private lateinit var cryptoService: CryptoServiceIntegration
+    private lateinit var webClient: MockableWebClient
+
+    @BeforeEach
+    fun beforeEach() {
+        webClient = MockableWebClient()
+        cryptoService =
+            CryptoServiceIntegration(
+                cryptoServiceConnector = mockk<CryptoServiceConnector>().also { every { it.webClient } returns webClient.webClient },
+            )
+    }
+
+    @Test
+    fun `test encrypt`() {
+        webClient.queueResponse(MockableResponse("encrypted_string", MediaType.TEXT_PLAIN))
+
+        runBlocking {
+            val response =
+                cryptoService.encrypt(
+                    text = "test",
+                    sopsConfig =
+                        SopsConfig(
+                            shamir_threshold = 2,
+                            key_groups = null,
+                            gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                        ),
+                    gcpAccessToken = GCPAccessToken("testToken"),
+                    riScId = "riScId",
+                )
+
+            assertEquals(
+                "encrypted_string",
+                response,
+                "The returned string should be the same as the one supplied by the crypto service.",
+            )
+        }
+    }
+
+    @Test
+    fun `test encrypt no response`() {
+        runBlocking {
+            assertThrows<SopsEncryptionException>("Should throw a SOPSEncryptionException on no response") {
+                cryptoService.encrypt(
+                    text = "test",
+                    sopsConfig =
+                        SopsConfig(
+                            shamir_threshold = 2,
+                            key_groups = null,
+                            gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                        ),
+                    gcpAccessToken = GCPAccessToken("testToken"),
+                    riScId = "riScId",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `test decrypt`() {
+        val risc =
+            RiScWithConfig(
+                riSc = "test",
+                sopsConfig =
+                    SopsConfig(
+                        shamir_threshold = 2,
+                        key_groups = null,
+                        gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                    ),
+            )
+
+        webClient.queueResponse(mockableResponseFromObject(risc))
+
+        runBlocking {
+            val returnedRisc = cryptoService.decrypt("test", GCPAccessToken("testToken"))
+
+            assertEquals(
+                risc,
+                returnedRisc,
+                "Returned RiSc with SOPS configuration should be the same as returned from the web request.",
+            )
+        }
+
+        val request = webClient.getNextRequest()
+        assertTrue(
+            request.headers.containsKey("gcpAccessToken"),
+            "Crypto service expects the GCP Access Token to be passed as an HTTP header.",
+        )
+
+        val gcpAccessTokenHeader = request.headers.getOrDefault("gcpAccessToken", emptyList())
+        assertEquals(1, gcpAccessTokenHeader.size, "There should be one GCP Access Token given in the HTTP header.")
+        assertEquals(
+            "testToken",
+            gcpAccessTokenHeader[0],
+            "The GCP Access Token in the HTTP header differs from the one passed to the decrypt function.",
+        )
+    }
+
+    @Test
+    fun `test decrypt unexpected answer`() {
+        webClient.queueResponse(MockableResponse("{\"test\": \"test\"}"))
+        runBlocking {
+            assertThrows<SOPSDecryptionException>("Should throw a SOPSDecryptionException on unexpected content") {
+                cryptoService.decrypt(
+                    "test",
+                    GCPAccessToken("testToken"),
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
@@ -119,7 +119,7 @@ class CryptoServiceIntegrationTests {
     }
 
     @Test
-    fun `test decrypt unexpected answer`() {
+    fun `test decrypt unexpected answer format`() {
         webClient.queueResponse(MockableResponse("{\"test\": \"test\"}"))
         runBlocking {
             assertThrows<SOPSDecryptionException>("Should throw a SOPSDecryptionException on unexpected content") {


### PR DESCRIPTION
Cleans up and tests the crypto service integration.

Introduces [MockK](https://mockk.io/) as a test dependency for mocking.

For simplicity and due to a [bug in MockK](https://github.com/mockk/mockk/issues/1300), a simple, custom utility class for mocking a WebClient object is created.