### PR TITLE
Allow additional GCP keys to be used by the application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ GITHUB_APP_PRIVATE_KEY=... # Private key of the GitHub app used by users of RiSc
 GITHUB_APP_INSTALLATION_ID=... # Installation ID of the GitHub app used by users of RiSc-plugin without GitHub account.
 BACKEND_PUBLIC_KEY="age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf" # The public key part used for encryption of RiSc's.
 
+# A list of names of GCP keys that should be used by the system, beyond those that contain "-prod-". This value does
+# not need to be set. If not set, no keys beyond those that contain "-prod-" will be used.
+# ADDITIONAL_ALLOWED_GCP_KEY_NAMES=name-of-key,name-of-other-key,name-of-third-key
+
 ### Image build args (optional) ###
 # The default image is currently not compatible with the M4 Mac architecture.
 # These args may be used to specify a compatible image ("amazoncorretto" has worked so far).

--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -23,6 +23,7 @@ import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.risc.ProcessingStatus
 import no.risc.sops.model.GcpCryptoKeyObject
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.bodyToMono
@@ -33,6 +34,7 @@ class GoogleServiceIntegration(
     private val gcpCloudResourceApiConnector: GcpCloudResourceApiConnector,
     private val gcpKmsApiConnector: GcpKmsApiConnector,
     private val gcpKmsInventoryApiConnector: GcpKmsInventoryApiConnector,
+    @Value("\${googleService.additionalAllowedGCPKeyNames}") private val additionalAllowedGCPKeyNames: List<String>,
 ) {
     companion object {
         val LOGGER = LoggerFactory.getLogger(GoogleServiceIntegration::class.java)
@@ -134,7 +136,7 @@ class GoogleServiceIntegration(
                         ProcessingStatus.FailedToFetchGcpProjectIds,
                     )
             gcpProjectIds
-                .filter { it.value.contains("-prod-") }
+                .filter { it.value.contains("-prod-") || additionalAllowedGCPKeyNames.contains(it.value) }
                 .map {
                     it to
                         async(Dispatchers.IO) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,5 @@ sops.backendPublicKey=${BACKEND_PUBLIC_KEY}
 github.app.private-key=${GITHUB_APP_PRIVATE_KEY}
 github.app.installation-id=${GITHUB_APP_INSTALLATION_ID}
 github.app.id=${GITHUB_APP_ID}
+# The application ignores all GCP keys that do not contain "-prod-" OR are included in this property.
+googleService.additionalAllowedGCPKeyNames=${ADDITIONAL_ALLOWED_GCP_KEY_NAMES:}


### PR DESCRIPTION
Currently, the application only considers GCP keys with names that contain `-prod-`. This filter was removed in #366 and later reintroduced in #373, as the removal lead to HTTP 429 responses from Google Cloud KMS. This PR makes it possible to specify specific GCP key names to be considered by the application beyond those containing -prod-. The change should be sufficient for our use case, in which every key used in production contains `-prod-` and there is only a need for a small number of other keys locals.

The additional GCP keys are specified through the environment variable `$ADDITIONAL_ALLOWED_GCP_KEY_NAMES`, which assumes the value to be a comma-separated list.