### PR TITLE
Simplifications to GithubConnector

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -27,6 +27,7 @@ import no.risc.risc.RiScStatus
 import no.risc.risc.models.UserInfo
 import no.risc.utils.decodeBase64
 import no.risc.utils.encodeBase64
+import no.risc.utils.tryOrNull
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
@@ -343,8 +344,8 @@ class GithubConnector(
         repository: String,
         accessToken: String,
         riScId: String,
-    ): LastPublished? {
-        return try {
+    ): LastPublished? =
+        tryOrNull {
             val lastCommitOnPath =
                 getGithubResponseSuspend(
                     githubHelper.uriToFetchCommits(
@@ -367,11 +368,8 @@ class GithubConnector(
                     accessToken,
                 ).awaitBody<List<GithubRefCommitDTO>>().size
 
-            return LastPublished(dateOfLastPublished, numberOfCommitsSinceDateTime)
-        } catch (e: Exception) {
-            null
+            LastPublished(dateOfLastPublished, numberOfCommitsSinceDateTime)
         }
-    }
 
     internal fun updateOrCreateDraft(
         owner: String,
@@ -543,18 +541,11 @@ class GithubConnector(
         repository: String,
         riScId: String,
         accessToken: String,
-    ) = try {
+    ) = tryOrNull {
         getGithubResponse(
-            uri =
-                githubHelper.uriToFindRiScOnDraftBranch(
-                    owner = owner,
-                    repository = repository,
-                    riScId = riScId,
-                ),
+            uri = githubHelper.uriToFindRiScOnDraftBranch(owner = owner, repository = repository, riScId = riScId),
             accessToken = accessToken,
         ).shaResponseDTO()
-    } catch (e: Exception) {
-        null
     }
 
     private fun getSHAForPublishedRiScOrNull(
@@ -562,18 +553,11 @@ class GithubConnector(
         repository: String,
         riScId: String,
         accessToken: String,
-    ) = try {
+    ) = tryOrNull {
         getGithubResponse(
-            uri =
-                githubHelper.uriToFindRiSc(
-                    owner = owner,
-                    repository = repository,
-                    id = riScId,
-                ),
+            uri = githubHelper.uriToFindRiSc(owner = owner, repository = repository, id = riScId),
             accessToken = accessToken,
         ).shaResponseDTO()
-    } catch (e: Exception) {
-        null
     }
 
     private suspend fun pullRequestForRiScExists(
@@ -674,7 +658,7 @@ class GithubConnector(
         riScId: String,
         branch: String,
     ): String? =
-        try {
+        tryOrNull {
             getGithubResponse(
                 uri =
                     githubHelper.uriToFetchCommit(
@@ -685,8 +669,6 @@ class GithubConnector(
                     ),
                 accessToken = accessToken,
             ).timeStampLatestCommitResponse()
-        } catch (e: Exception) {
-            null
         }
 
     fun createPullRequestForRiSc(

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -254,7 +254,7 @@ class GithubHelper(
         branchName: String,
     ): String = "/$owner/$repository/commits/$branchName/status"
 
-    fun uriToCreateNewBranchForRiSc(
+    fun uriToCreateNewBranch(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository/git/refs"

--- a/src/main/kotlin/no/risc/utils/Utils.kt
+++ b/src/main/kotlin/no/risc/utils/Utils.kt
@@ -46,3 +46,14 @@ fun generateRandomAlphanumericString(
         .limit(length.toLong())
         .toArray()
         .joinToString(separator = "")
+
+/**
+ * Returns the result of the provided function, unless the provided function throws an exception. If an exception is
+ * thrown, then null is returned.
+ */
+inline fun <T> tryOrNull(func: () -> T?) =
+    try {
+        func()
+    } catch (_: Exception) {
+        null
+    }


### PR DESCRIPTION
Simplifies and standardises parts of the GithubConnector code to prepare it for testing. More simplifications are to come, but are split into multiple PRs to simplify reviewing. This PR tries to simplify the code in the following manner:

- Simplify calls that should return null on exceptions
- Remove unnecessary usage of `when` (used multiple times when there is only one specific case and then an `else` block, see [the Kotlin docs](https://kotlinlang.org/docs/coding-conventions.html#if-versus-when)).
- Removes duplication of code related to `WebClient`. Currently, changes to API versions, headers and similar need to be made in multiple places in the code. With this change, these values are set in one place, reducing code duplication and simplifying the amount of work needed to deal with any future changes to the GitHub API.
- Starts adding doc strings (to most of the methods changed in this PR).