### PR TITLE
Simplify create pull request code

### DIFF
--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -147,7 +147,7 @@ internal class GlobalExceptionHandler {
     fun handleCreatePullRequestException(ex: CreatePullRequestException): ProcessRiScResultDTO {
         logger.error(ex.message, ex)
         return ProcessRiScResultDTO(
-            riScId = ex.riScId,
+            riScId = "",
             status = ProcessingStatus.ErrorWhenCreatingPullRequest,
             statusMessage = ex.message,
         )

--- a/src/main/kotlin/no/risc/exception/exceptions/CreatePullRequestException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/CreatePullRequestException.kt
@@ -2,5 +2,4 @@ package no.risc.exception.exceptions
 
 data class CreatePullRequestException(
     override val message: String,
-    val riScId: String,
 ) : Exception()

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
-import no.risc.risc.models.UserInfo
 import no.risc.sops.model.PullRequestObject
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -284,31 +283,6 @@ class GithubHelper(
     fun bodyToClosePullRequest(): String =
         "{ \"title\":\"Closed\", \"body\": \"The PR was closed when risk scorecard was updated. " +
             "New approval from risk owner is required.\",  \"state\": \"closed\"}"
-
-    fun bodyToCreateNewPullRequest(
-        repositoryOwner: String,
-        requiresNewApproval: Boolean,
-        riScRiskOwner: UserInfo,
-        branch: String,
-        baseBranch: String,
-    ): GithubCreateNewPullRequestPayload {
-        val body =
-            when (requiresNewApproval) {
-                true ->
-                    "${riScRiskOwner.name} (${riScRiskOwner.email}) has approved the risk scorecard. " +
-                        "Merge the pull request to include the changes in the default branch."
-
-                false -> "The risk scorecard has been updated, but does not require new approval."
-            }
-
-        return GithubCreateNewPullRequestPayload(
-            title = "Updated risk scorecard",
-            body = body,
-            repositoryOwner = repositoryOwner,
-            branch = branch,
-            baseBranch = baseBranch,
-        )
-    }
 
     fun bodyToCreateNewBranchFromDefault(
         branchName: String,

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -128,31 +128,20 @@ class RiScController(
         @PathVariable repositoryName: String,
         @PathVariable id: String,
         @RequestBody userInfo: UserInfo,
-    ): ResponseEntity<PublishRiScResultDTO> {
-        val result =
-            riScService.publishRiSc(
-                owner = repositoryOwner,
-                repository = repositoryName,
-                riScId = id,
-                accessTokens =
-                    AccessTokens(
-                        gcpAccessToken = GCPAccessToken(gcpAccessToken),
-                        githubAccessToken = GithubAccessToken(gitHubAccessToken),
-                    ),
-                userInfo = userInfo,
-                baseBranch =
-                    githubConnector.fetchDefaultBranch(
-                        repositoryOwner = repositoryOwner,
-                        repositoryName = repositoryName,
-                        gitHubAccessToken = gitHubAccessToken,
-                    ),
-            )
-
-        return when (result.status) {
-            ProcessingStatus.CreatedPullRequest -> ResponseEntity.ok().body(result)
-            else -> ResponseEntity.internalServerError().body(result)
-        }
-    }
+    ): PublishRiScResultDTO =
+        riScService.publishRiSc(
+            owner = repositoryOwner,
+            repository = repositoryName,
+            riScId = id,
+            gitHubAccessToken = gitHubAccessToken,
+            userInfo = userInfo,
+            baseBranch =
+                githubConnector.fetchDefaultBranch(
+                    repositoryOwner = repositoryOwner,
+                    repositoryName = repositoryName,
+                    gitHubAccessToken = gitHubAccessToken,
+                ),
+        )
 
     @PostMapping("/{repositoryOwner}/{repositoryName}/{riscId}/difference", produces = ["application/json"])
     suspend fun getDifferenceBetweenTwoRiScs(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -1,4 +1,5 @@
 package no.risc.risc
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -662,7 +663,7 @@ class RiScService(
         owner: String,
         repository: String,
         riScId: String,
-        accessTokens: AccessTokens,
+        gitHubAccessToken: String,
         userInfo: UserInfo,
         baseBranch: String,
     ): PublishRiScResultDTO {
@@ -672,28 +673,17 @@ class RiScService(
                 repository = repository,
                 riScId = riScId,
                 requiresNewApproval = true,
-                accessTokens = accessTokens,
+                gitHubAccessToken = gitHubAccessToken,
                 userInfo = userInfo,
                 baseBranch = baseBranch,
             )
 
-        return when (pullRequestObject) {
-            is GithubPullRequestObject ->
-                PublishRiScResultDTO(
-                    riScId = riScId,
-                    status = ProcessingStatus.CreatedPullRequest,
-                    statusMessage = "Pull request was created",
-                    pendingApproval = pullRequestObject.toPendingApprovalDTO(),
-                )
-
-            else ->
-                PublishRiScResultDTO(
-                    riScId = riScId,
-                    status = ProcessingStatus.ErrorWhenCreatingPullRequest,
-                    statusMessage = "Could not create pull request",
-                    pendingApproval = null,
-                )
-        }
+        return PublishRiScResultDTO(
+            riScId = riScId,
+            status = ProcessingStatus.CreatedPullRequest,
+            statusMessage = "Pull request was created",
+            pendingApproval = pullRequestObject.toPendingApprovalDTO(),
+        )
     }
 
     private fun GithubPullRequestObject.toPendingApprovalDTO(): PendingApprovalDTO =

--- a/src/main/kotlin/no/risc/sops/SopsController.kt
+++ b/src/main/kotlin/no/risc/sops/SopsController.kt
@@ -82,10 +82,6 @@ class SopsController(
         repositoryOwner = repositoryOwner,
         repositoryName = repositoryName,
         sopsId = branch,
-        githubAccessToken =
-            AccessTokens(
-                githubAccessToken = GithubAccessToken(gitHubAccessToken),
-                gcpAccessToken = GCPAccessToken(gcpAccessToken),
-            ).githubAccessToken,
+        gitHubAccessToken = gitHubAccessToken,
     )
 }

--- a/src/main/kotlin/no/risc/sops/SopsService.kt
+++ b/src/main/kotlin/no/risc/sops/SopsService.kt
@@ -2,13 +2,11 @@ package no.risc.sops
 
 import no.risc.config.SopsServiceConfig
 import no.risc.exception.exceptions.CreateNewBranchException
-import no.risc.exception.exceptions.GitHubFetchException
 import no.risc.github.GithubConnector
 import no.risc.google.GoogleServiceIntegration
 import no.risc.infra.connector.GcpCloudResourceApiConnector
 import no.risc.infra.connector.GcpKmsApiConnector
 import no.risc.infra.connector.models.AccessTokens
-import no.risc.infra.connector.models.GithubAccessToken
 import no.risc.initRiSc.InitRiScServiceIntegration
 import no.risc.risc.ProcessRiScResultDTO
 import no.risc.risc.ProcessingStatus
@@ -179,13 +177,13 @@ class SopsService(
         repositoryOwner: String,
         repositoryName: String,
         sopsId: String,
-        githubAccessToken: GithubAccessToken,
+        gitHubAccessToken: String,
     ): OpenPullRequestForSopsConfigResponseBody {
         val defaultBranch =
             githubConnector.fetchDefaultBranch(
                 repositoryOwner = repositoryOwner,
                 repositoryName = repositoryName,
-                gitHubAccessToken = githubAccessToken.value,
+                gitHubAccessToken = gitHubAccessToken,
             )
         val pullRequestObject =
             githubConnector
@@ -193,16 +191,9 @@ class SopsService(
                     owner = repositoryOwner,
                     repository = repositoryName,
                     sopsId = sopsId,
-                    gitHubAccessToken = githubAccessToken,
-                    defaultBranch = defaultBranch,
-                )?.toPullRequestObject() ?: throw GitHubFetchException(
-                "Unable to create pull request for sops config with branch: $sopsId",
-                ProcessRiScResultDTO(
-                    riScId = "",
-                    status = ProcessingStatus.ErrorWhenCreatingPullRequest,
-                    statusMessage = ProcessingStatus.ErrorWhenCreatingPullRequest.message,
-                ),
-            )
+                    gitHubAccessToken = gitHubAccessToken,
+                    baseBranch = defaultBranch,
+                ).toPullRequestObject()
         return OpenPullRequestForSopsConfigResponseBody(
             status = ProcessingStatus.OpenedPullRequest,
             statusMessage = ProcessingStatus.OpenedPullRequest.message,


### PR DESCRIPTION
Currently, the code for creating pull requests is used two places with similar usage patterns, but with differing implementations. This PR simplifies the code for this functionality by collecting shared (and relevant) functionality in the code shared by two implementations. Also removes code that could never be reached and standardises the implementation across the two locations as far as possible.