### PR TITLE
Remove pull_request trigger from GCP deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -6,9 +6,6 @@ on:
       - README**
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 env:
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Trenger ikke å deploye hvert eneste bygg i hver PR. Trenger det kun når det merges til main