### PR TITLE
Simplify GithubConnector

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -12,9 +12,7 @@ data class GithubReferenceObjectDTO(
     val url: String,
     @JsonProperty("object")
     val shaObject: GithubRefShaDTO,
-) {
-    fun toInternal(): GithubReferenceObject = GithubReferenceObject(ref, url, shaObject.sha)
-}
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GithubRefShaCommitCommiter(
@@ -37,12 +35,6 @@ data class GithubRefCommitDTO(
     val sha: String,
     val url: String,
     val commit: GithubRefShaCommit,
-)
-
-data class GithubReferenceObject(
-    val ref: String,
-    val url: String,
-    val sha: String,
 )
 
 data class GithubCreateNewBranchPayload(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -315,7 +315,7 @@ class RiScService(
                         repository = repository,
                         accessToken = accessTokens.githubAccessToken.value,
                     ).ids
-            LOGGER.info("Found RiSc's with id's: ${riScIds.map { it.id }.joinToString(", ")}")
+            LOGGER.info("Found RiSc's with id's: ${riScIds.joinToString(", ") { it.id }}")
             val riScContents =
                 riScIds
                     .associateWith { id ->


### PR DESCRIPTION
A continuation of the simplification and documentation work for `GithubConnector` started in #376 and #380. The changes in this PR are mostly related to

- `fetchRepositoryInfo`, which fetches information about the repository (default branch, etc.).
- `fetchRiscContent`, which fetches the content of a RiSc from the appropriate location in the repository.
- `fetchRiscIdentifiers`, which fetches a list of identifiers for the RiScs present in the repository.

There are also some other minor changes.

Currently, mocking webrequests is tiresome due to serialisation using either `kotlinx.serialization` or `fasterxml.jackson` somewhat arbitrarily. To simplify testing, unit tests for this functionality of GithubConnector will be included in a separate PR after a rewrite to a single one of these serialisation libraries.