### PR TITLE
Change dependency for JSON schema validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ val kotlinxCoroutinesVersion = "1.10.2"
 val nettyVersion = "4.2.0.Final"
 val micrometerVersion = "1.14.5"
 val fasterXmlJacksonVersion = "2.18.3"
-val kotlinJsonSchemaVersion = "0.56"
+val jsonSchemaValidatorVersion = "1.5.6"
 val googleGsonVersion = "2.12.1"
 val googleAuthVersion = "1.33.1"
 val nimbusdsVersion = "10.2"
@@ -71,8 +71,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$fasterXmlJacksonVersion")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$fasterXmlJacksonVersion")
-    implementation("net.pwall.json:json-kotlin-schema:$kotlinJsonSchemaVersion")
+    implementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
 
     implementation("com.google.code.gson:gson:$googleGsonVersion")
     implementation("com.google.auth:google-auth-library-credentials:$googleAuthVersion")

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -585,7 +585,6 @@ class RiScService(
                 riScContent = content.riSc,
             )
         if (!validationStatus.isValid) {
-            // val validationError = validationStatus.errors?.joinToString("\n") { it.error }.toString()
             val validationError =
                 validationStatus.details.joinToString("\n") { detail ->
                     detail.errors.values.joinToString("\n") { error -> "${detail.instanceLocation}: $error" }

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -410,7 +410,7 @@ class RiScService(
                                     riScId = riScContentResultDTO.riScId,
                                     riScContent = riScContentResultDTO.riScContent,
                                 )
-                            when (validationStatus.valid) {
+                            when (validationStatus.isValid) {
                                 true -> {
                                     LOGGER.info("RiSc with id: ${riScContentResultDTO.riScId} successfully validated")
                                     riScContentResultDTO
@@ -584,8 +584,12 @@ class RiScService(
                 schema = JSONValidator.getSchemaOnUpdate(riScId, content.schemaVersion),
                 riScContent = content.riSc,
             )
-        if (!validationStatus.valid) {
-            val validationError = validationStatus.errors?.joinToString("\n") { it.error }.toString()
+        if (!validationStatus.isValid) {
+            // val validationError = validationStatus.errors?.joinToString("\n") { it.error }.toString()
+            val validationError =
+                validationStatus.details.joinToString("\n") { detail ->
+                    detail.errors.values.joinToString("\n") { error -> "${detail.instanceLocation}: $error" }
+                }
             throw RiScNotValidOnUpdateException(
                 message = "Failed when validating RiSc with error message: $validationError",
                 riScId = riScId,

--- a/src/test/kotlin/no/risc/validation/JSONValidatorTests.kt
+++ b/src/test/kotlin/no/risc/validation/JSONValidatorTests.kt
@@ -42,20 +42,20 @@ class JSONValidatorTests {
     @Test
     fun `test validate against schema without output`() {
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = null)
-        assertFalse(output.valid, "When no risc content is provided, validation should be false")
+        assertFalse(output.isValid, "When no risc content is provided, validation should be false")
     }
 
     @Test
     fun `test validate against unspecified schema with invalid content`() {
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = "{ \"a\": 123 }")
-        assertFalse(output.valid)
+        assertFalse(output.isValid)
     }
 
     @Test
     fun `test validate against specified schema with invalid content`() {
         val output =
             JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = "{ \"a\": 123 }", schema = testSchema)
-        assertFalse(output.valid)
+        assertFalse(output.isValid)
     }
 
     @Test
@@ -66,7 +66,7 @@ class JSONValidatorTests {
                 riScContent = "{ \"a\": 123, \"b\": [\"abc\", \"cde\"] }",
                 schema = testSchema,
             )
-        assertTrue(output.valid)
+        assertTrue(output.isValid)
     }
 
     @Test
@@ -104,14 +104,14 @@ class JSONValidatorTests {
             """.trimIndent()
 
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = validYAML, schema = testSchema)
-        assertTrue(output.valid, "Valid YAML should return a validation output with valid set to true")
+        assertTrue(output.isValid, "Valid YAML should return a validation output with valid set to true")
     }
 
     @Test
     fun `test validate version 3_2 without specifying scheme`() {
         val content = getResource("3.2.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content)
-        assertTrue(output.valid, "Content adhering to version 3.2 should successfully be validated")
+        assertTrue(output.isValid, "Content adhering to version 3.2 should successfully be validated")
     }
 
     @Test
@@ -120,7 +120,7 @@ class JSONValidatorTests {
         val content = getResource("3.2.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
         assertTrue(
-            output.valid,
+            output.isValid,
             "Content adhering to version 3.2 should be successfully validated against the version 3.2 schema.",
         )
     }
@@ -129,7 +129,7 @@ class JSONValidatorTests {
     fun `test validate version 3_3 without specifying scheme`() {
         val content = getResource("3.3.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content)
-        assertTrue(output.valid, "Content adhering to version 3.3 should successfully be validated")
+        assertTrue(output.isValid, "Content adhering to version 3.3 should successfully be validated")
     }
 
     @Test
@@ -138,7 +138,7 @@ class JSONValidatorTests {
         val content = getResource("3.3.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
         assertTrue(
-            output.valid,
+            output.isValid,
             "Content adhering to version 3.3 should be successfully validated against the version 3.3 schema.",
         )
     }
@@ -149,7 +149,7 @@ class JSONValidatorTests {
         val content = getResource("4.0.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
         assertFalse(
-            output.valid,
+            output.isValid,
             "Content adhering to version 4.0 should fail validation against the version 3.3 schema.",
         )
     }
@@ -158,7 +158,7 @@ class JSONValidatorTests {
     fun `test validate version 4_0 without specifying scheme`() {
         val content = getResource("4.0.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content)
-        assertTrue(output.valid, "Content adhering to version 4.0 should successfully be validated")
+        assertTrue(output.isValid, "Content adhering to version 4.0 should successfully be validated")
     }
 
     @Test
@@ -167,7 +167,7 @@ class JSONValidatorTests {
         val content = getResource("4.0.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
         assertTrue(
-            output.valid,
+            output.isValid,
             "Content adhering to version 4.0 should be successfully validated against the version 4.0 schema.",
         )
     }
@@ -178,7 +178,7 @@ class JSONValidatorTests {
         val content = getResource("3.3.json")
         val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
         assertFalse(
-            output.valid,
+            output.isValid,
             "Content adhering to version 3.3 should fail validation against the version 4.0 schema.",
         )
     }

--- a/src/test/resources/4.0.json
+++ b/src/test/resources/4.0.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "3.3",
+  "schemaVersion": "4.0",
   "title": "Transformasjon",
   "scope": "Sikkerhet av backend.",
   "valuations": [],


### PR DESCRIPTION
This PR is part of a process to remove the dependency on FasterXML Jackson libraries in the project. Currently, the project uses both FasterXML Jackson and KotlinX for serialization libraries for API calls to/from the backend. Both of these libraries provide similar functionality and are not commonly used together, as it is sufficient with one library. In particular, the usage of two libraries complicates serialization and deserialization when mocking `WebClient` calls for testing. As the serialization library of KotlinX is significantly more integrated in the Kotlin ecosystem (it is maintained by part of the Kotlin team), KotlinX Serialization is chosen over FasterXML Jackson.

This PR removes a direct dependency on the FasterXML Jackson YAML library (`com.fasterxml.jackson.dataformat:jackson-dataformat-yaml`), which is used to convert YAML to JSON for schema validation with `net.pwall.json:json-kotlin-schema`. The dependency is removed by changing the JSON schema validation library from [pwall JSON-Kotlin-Schema](https://github.com/pwall567/json-kotlin-schema/) (`net.pwall.json:json-kotlin-schema`) to the much more mature [networknt JSON-Schema-Validator](https://github.com/networknt/json-schema-validator) (`com.networknt:json-schema-validator`) which also provides YAML Schema validation out of the box.