### PR TITLE
Remove unused Maven repository. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,6 @@ java {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://dist.wso2.org/maven2/public")
-    }
 }
 
 val kotlinVersion = "2.1.20"


### PR DESCRIPTION
All dependencies used are found in the Maven central repository and Gradle retrieves dependencies from the first entry in the repository list where the given dependency is available. Thus, the removed repository is for this reason never used. Further, it cannot satisfy any of the dependencies used in the project. So it does not work as a backup in case the Maven central repository would be down.