### PR TITLE
Remove unused dependency to io.netty:netty-all

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
-    implementation("io.netty:netty-all:$nettyVersion")
-
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
         because("Provides endpoints for health and event monitoring that are used in SKIP.")
     }


### PR DESCRIPTION
This dependency was introduced in #86, but seems to never have been used. The Spring Boot web server uses Tomcat and not Netty.