### PR TITLE
Remove unused dependency to com.google.auth:google-auth-library-credentials

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,6 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$fasterXmlJacksonVersion")
     implementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
 
-    implementation("com.google.auth:google-auth-library-credentials:$googleAuthVersion")
-
     implementation("com.nimbusds:nimbus-jose-jwt:$nimbusdsVersion")
     implementation("org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion")
 


### PR DESCRIPTION
This dependency was added in #63, but seem to never have been used.