### PR TITLE
Risc status fix

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -315,7 +315,7 @@ class GithubConnector(
         } catch (e: Exception) {
             emptyList()
         }
-    
+
     internal suspend fun fetchLastPublishedRiScDateAndCommitNumber(
         owner: String,
         repository: String,
@@ -332,7 +332,7 @@ class GithubConnector(
                     ),
                     accessToken,
                 ).awaitBody<List<GithubRefCommitDTO>>().first().commit.committer.dateTime
-            
+
             val commits =
                 getGithubResponse(
                     githubHelper.uriToFetchCommitsSince(
@@ -342,11 +342,13 @@ class GithubConnector(
                     ),
                     accessToken,
                 ).awaitBody<List<GithubRefCommitDTO>>()
-            
-            val commitsAfterPublish = commits.filter {
-                it.commit.committer.dateTime.isAfter(lastPublishedDate)
-            }
-            
+
+            val commitsAfterPublish =
+                commits.filter {
+                    it.commit.committer.dateTime
+                        .isAfter(lastPublishedDate)
+                }
+
             LastPublished(lastPublishedDate, commitsAfterPublish.size)
         }
 


### PR DESCRIPTION
The RiSc status in this repo differs from the status in sikkerhetsmetrikker-plugin because the fetchLastPublishedRiScDateAndCommitNumber function includes the commit that updated the RiSc.

**Solution:**
Fixes the issue by filtering out commits with a timestamp equal to or earlier than the RiSc’s last-published date, ensuring the RiSc-updating commit is excluded from the count.