### PR TITLE
Testing and documentation for GoogleServiceIntegration

### DIFF
--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -37,8 +37,21 @@ class GoogleServiceIntegration(
         val LOGGER: Logger = LoggerFactory.getLogger(GoogleServiceIntegration::class.java)
     }
 
+    /**
+     * Checks if the provided GCP OAuth2 token is valid by contacting a Google APIs endpoint.
+     *
+     * @param token The OAuth2 token to validate.
+     */
     suspend fun validateAccessToken(token: String): Boolean = fetchTokenInfo(token) != null
 
+    /**
+     * Retrieves information about the provided GCP OAuth2 token from a Google APIs endpoint. If the token is not valid,
+     * a null value is returned. If the token is valid, a serialised JSON object is returned.
+     *
+     * @see <a href="https://cloud.google.com/docs/authentication/token-types#access">Google APIs endpoint documentation</a>
+     *
+     * @param token The OAuth2 token to retrieve information for.
+     */
     private suspend fun fetchTokenInfo(token: String): String? =
         try {
             googleOAuthApiConnector.webClient
@@ -53,6 +66,11 @@ class GoogleServiceIntegration(
             )
         }
 
+    /**
+     * Fetches the IDs of projects that can be accessed by the provided GCP access token.
+     *
+     * @param gcpAccessToken The GCP access token to retrieve project IDs for.
+     */
     private suspend fun fetchProjectIds(gcpAccessToken: GCPAccessToken): List<GcpProjectId> =
         try {
             gcpCloudResourceApiConnector.webClient
@@ -67,6 +85,13 @@ class GoogleServiceIntegration(
             throw FetchException("Failed to fetch GCP projects", ProcessingStatus.FailedToFetchGcpProjectIds)
         }
 
+    /**
+     * Verifies that the given GCP access token has the provided GCP IAM permissions in the given crypto key resource.
+     *
+     * @param cryptoKeyResourceId The resource ID (GCP project ID) for the crypto key to test permissions for.
+     * @param gcpAccessToken The GCP access token to test permission levels for.
+     * @param permissions The required GCP IAM permissions.
+     */
     private suspend fun testIAMPermissions(
         cryptoKeyResourceId: String,
         gcpAccessToken: GCPAccessToken,
@@ -90,6 +115,12 @@ class GoogleServiceIntegration(
             )
         }
 
+    /**
+     * Retrieves all GCP crypto keys that can be accessed with the provided GCP access token, provided their name
+     * includes either "-prod-" or is configured in the `additionalAllowedGCPKeyNames` property.
+     *
+     * @param gcpAccessToken The GCP access token to retrieve keys for.
+     */
     suspend fun getGcpCryptoKeys(gcpAccessToken: GCPAccessToken): List<GcpCryptoKeyObject> =
         coroutineScope {
             LOGGER.info("Fetching GCP crypto keys")

--- a/src/main/kotlin/no/risc/google/model/DTOs.kt
+++ b/src/main/kotlin/no/risc/google/model/DTOs.kt
@@ -22,12 +22,12 @@ data class GcpProject(
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
 @JsonIgnoreUnknownKeys
-data class TestIamPermissionBody(
-    val permissions: List<GcpIamPermission>? = null,
+data class TestIAMPermissionBody(
+    val permissions: List<GcpIAMPermission>? = null,
 )
 
 @Serializable
-enum class GcpIamPermission {
+enum class GcpIAMPermission {
     @SerialName("cloudkms.cryptoKeyVersions.useToEncrypt")
     USE_TO_ENCRYPT,
 

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -156,6 +156,8 @@ enum class ProcessingStatus(
     AccessTokensValidationFailure("Failure when validating access tokens"),
     ErrorWhenGeneratingInitialRiSc("Error when generating initial risk scorecard"),
     FailedToFetchGcpProjectIds("Failed to fetch GCP project IDs"),
+    FailedToFetchGCPOAuth2TokenInformation("Failed to fetch GCP OAuth2 token information"),
+    FailedToFetchGCPIAMPermissions("Failed to fetch GCP IAM permissions for crypto key"),
     FailedToCreateSops("Failed to create SOPS configuration"),
 }
 

--- a/src/test/kotlin/WebClientUtil.kt
+++ b/src/test/kotlin/WebClientUtil.kt
@@ -1,4 +1,3 @@
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -6,22 +5,47 @@ import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
+import java.net.URI
 
+/**
+ * A data class for keeping track of a response that should be returned by the mocked web client.
+ */
 data class MockableResponse(
     val content: String,
     val contentType: MediaType = MediaType.APPLICATION_JSON,
     val httpStatus: HttpStatus = HttpStatus.OK,
 )
 
+/**
+ * Creates a MockableResponse with content set to a JSON encoded string of the provided object.
+ *
+ * @param obj The object to encode as JSON.
+ */
 inline fun <reified T> mockableResponseFromObject(obj: T): MockableResponse = MockableResponse(content = Json.encodeToString<T>(obj))
 
+/**
+ * A data class for keeping track of the requests sent by the application through the mockable web client.
+ */
 data class MockableRequest(
     val content: String,
     val headers: Map<String, List<String>>,
+    val url: URI,
 )
 
+/**
+ * A handler for mocking a web client with tracking of received requests and queuing of custom responses. Can be used
+ * by substituting a `WebClient` instance with the `webClient` property of the `MockableWebClient` instance.
+ *
+ * Responses can be scheduled using the `queueResponse` method, which allows either scheduling for a specific URI path
+ * or a wildcard match for any request. When a request is made through the `WebClient` instance, a response is selected
+ * and consumed based on the first match in the prioritised list:
+ * 1. A scheduled response matching the path-part of the request url (if multiple, the oldest is used).
+ * 2. A scheduled wildcard response (if multiple, the oldest is used).
+ * 3. An empty 200 OK response.
+ */
 class MockableWebClient {
-    private val responses = mutableListOf<MockableResponse>()
+    private val wildcardResponses = mutableListOf<MockableResponse>()
+    private val responses = mutableMapOf<String, List<MockableResponse>>()
     private val requests = mutableListOf<MockableRequest>()
     val webClient: WebClient =
         WebClient
@@ -29,26 +53,63 @@ class MockableWebClient {
             .exchangeFunction { handleRequest(it) }
             .build()
 
+    /**
+     * Handles a request build and sent through the web client. See the class documentation for how queued responses are
+     * selected.
+     *
+     * @see MockableWebClient
+     */
     private fun handleRequest(request: ClientRequest): Mono<ClientResponse> {
         requests.add(
             MockableRequest(
                 content = request.body().toString(),
                 headers = request.headers().toMap(),
+                url = request.url(),
             ),
         )
 
-        if (responses.isEmpty()) return Mono.empty()
-        val response = responses.removeFirst()
+        val requestPath = request.url().path
+
+        // No matching queued up response
+        if (requestPath !in responses && wildcardResponses.isEmpty()) return Mono.empty()
+
+        val response: MockableResponse
+
+        // Choose the closest matching response
+        if (requestPath in responses) {
+            response = responses[requestPath]!!.first()
+            // Remove the path if there are no queued responses
+            responses.compute(requestPath) { _, queuedResponses -> queuedResponses?.drop(1)?.ifEmpty { null } }
+        } else {
+            response = wildcardResponses.removeFirst()
+        }
+
         return Mono.just(
             ClientResponse
-                .create(HttpStatus.OK)
+                .create(response.httpStatus)
                 .header("content-type", response.contentType.toString())
                 .body(response.content)
                 .build(),
         )
     }
 
-    fun queueResponse(response: MockableResponse) = responses.add(response)
+    /**
+     * Queue a wildcard response
+     */
+    fun queueResponse(response: MockableResponse) = wildcardResponses.add(response)
 
+    /**
+     * Queue a response for a specific URI path
+     */
+    fun queueResponse(
+        response: MockableResponse,
+        path: String,
+    ) = responses.compute(path) { _, existingResponses ->
+        existingResponses?.plus(response) ?: listOf(response)
+    }
+
+    /**
+     * Retrieves and removes the oldest request made to the web client
+     */
     fun getNextRequest(): MockableRequest = requests.removeFirst()
 }

--- a/src/test/kotlin/no/risc/google/GoogleServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/google/GoogleServiceIntegrationTests.kt
@@ -5,13 +5,24 @@ import MockableWebClient
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import mockableResponseFromObject
+import no.risc.exception.exceptions.FetchException
+import no.risc.google.model.FetchGcpProjectIdsResponse
+import no.risc.google.model.GcpIAMPermission
+import no.risc.google.model.GcpProject
+import no.risc.google.model.GcpProjectId
+import no.risc.google.model.TestIAMPermissionBody
+import no.risc.google.model.getRiScCryptoKeyResourceId
 import no.risc.infra.connector.GcpCloudResourceApiConnector
 import no.risc.infra.connector.GcpKmsApiConnector
 import no.risc.infra.connector.GoogleOAuthApiConnector
+import no.risc.infra.connector.models.GCPAccessToken
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
 
 class GoogleServiceIntegrationTests {
@@ -23,6 +34,10 @@ class GoogleServiceIntegrationTests {
     fun beforeEach() {
         additionalAllowedGCPKeyNames = mutableListOf()
         webClient = MockableWebClient()
+        mockGoogleService(additionalAllowedGCPKeyNames)
+    }
+
+    fun mockGoogleService(additionalAllowedGCPKeyNames: List<String>) {
         googleService =
             GoogleServiceIntegration(
                 googleOAuthApiConnector = mockk<GoogleOAuthApiConnector>().also { every { it.webClient } returns webClient.webClient },
@@ -34,6 +49,16 @@ class GoogleServiceIntegrationTests {
                 gcpKmsApiConnector = mockk<GcpKmsApiConnector>().also { every { it.webClient } returns webClient.webClient },
                 additionalAllowedGCPKeyNames = additionalAllowedGCPKeyNames,
             )
+    }
+
+    /**
+     * Helper function for allowing additional GCP key names. This function is needed, as the Google service must be
+     * re-mocked each time an additional GCP key name is added to the allowed GCP key names, to propagate the changes to
+     * the private property in GoogleServiceIntegration.
+     */
+    fun allowGCPKeyName(keyName: String) {
+        additionalAllowedGCPKeyNames.add(keyName)
+        mockGoogleService(additionalAllowedGCPKeyNames)
     }
 
     @Test
@@ -60,10 +85,7 @@ class GoogleServiceIntegrationTests {
             path = "",
         )
 
-        val isAccessTokenValid =
-            runBlocking {
-                googleService.validateAccessToken("validAccessToken")
-            }
+        val isAccessTokenValid = runBlocking { googleService.validateAccessToken("validAccessToken") }
 
         assertTrue(
             isAccessTokenValid,
@@ -79,14 +101,184 @@ class GoogleServiceIntegrationTests {
             path = "",
         )
 
-        val isAccessTokenValid =
-            runBlocking {
-                googleService.validateAccessToken("invalidAccessToken")
-            }
+        val isAccessTokenValid = runBlocking { googleService.validateAccessToken("invalidAccessToken") }
 
         assertFalse(
             isAccessTokenValid,
             "A GCP access token should not be considered valid when no information is returned on it.",
+        )
+    }
+
+    private val fetchGCPProjectIdsURL = "/v1/projects"
+
+    private fun iamPermissionURL(keyName: String): String = "/v1/${GcpProjectId(keyName).getRiScCryptoKeyResourceId()}:testIamPermissions"
+
+    @Test
+    fun `test get GCP crypto keys`() {
+        val key1Name = "key1-prod-test"
+        val key2Name = "test-key-prod-test"
+
+        val projectIDs =
+            FetchGcpProjectIdsResponse(
+                projects =
+                    listOf(
+                        GcpProject(projectId = key1Name),
+                        GcpProject(projectId = key2Name),
+                    ),
+            )
+
+        webClient.queueResponse(response = mockableResponseFromObject(projectIDs), path = fetchGCPProjectIdsURL)
+
+        val permissionsKey1 =
+            TestIAMPermissionBody(
+                permissions =
+                    listOf(
+                        GcpIAMPermission.USE_TO_DECRYPT,
+                        GcpIAMPermission.USE_TO_ENCRYPT,
+                    ),
+            )
+
+        val permissionsKey2 =
+            TestIAMPermissionBody(permissions = listOf(GcpIAMPermission.USE_TO_DECRYPT))
+
+        webClient.queueResponse(
+            response = mockableResponseFromObject(permissionsKey1),
+            path = iamPermissionURL(key1Name),
+        )
+        webClient.queueResponse(
+            response = mockableResponseFromObject(permissionsKey2),
+            path = iamPermissionURL(key2Name),
+        )
+
+        val cryptoKeys = runBlocking { googleService.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken("testToken")) }
+
+        assertEquals(2, cryptoKeys.size, "Both crypto keys should be returned")
+        assertTrue(
+            cryptoKeys.any { it.projectId == key1Name && it.hasEncryptDecryptAccess },
+            "The crypto keys should include key1 ($key1Name) with encrypt and decrypt access.",
+        )
+        assertTrue(
+            cryptoKeys.any { it.projectId == key2Name && !it.hasEncryptDecryptAccess },
+            "The crypto keys should include key2 ($key2Name) without encrypt and decrypt access.",
+        )
+    }
+
+    @Test
+    fun `test get GCP crypto keys can't get project IDs`() {
+        webClient.queueResponse(response = MockableResponse(content = "", httpStatus = HttpStatus.BAD_REQUEST))
+
+        assertThrows<FetchException>("getGCPCryptoKeys should throw a FetchException when the call to get project IDs fails.") {
+            runBlocking { googleService.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken("testToken")) }
+        }
+    }
+
+    @Test
+    fun `test get GCP crypto keys can't get IAM permissions`() {
+        val keyName = "key-prod-test"
+        val projectIDs = FetchGcpProjectIdsResponse(projects = listOf(GcpProject(projectId = keyName)))
+
+        webClient.queueResponse(response = mockableResponseFromObject(projectIDs), path = fetchGCPProjectIdsURL)
+        webClient.queueResponse(
+            response = MockableResponse(content = "", httpStatus = HttpStatus.BAD_REQUEST),
+            path = iamPermissionURL(keyName),
+        )
+
+        assertThrows<FetchException>("getGCPCryptoKeys should throw a FetchException when a call to get IAM permissions fails") {
+            runBlocking { googleService.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken("testToken")) }
+        }
+    }
+
+    @Test
+    fun `test get GCP crypto keys non-production keys are ignored`() {
+        val key1Name = "key1-prod-test"
+        val key2Name = "test-key"
+
+        val projectIDs =
+            FetchGcpProjectIdsResponse(
+                projects =
+                    listOf(
+                        GcpProject(projectId = key1Name),
+                        GcpProject(projectId = key2Name),
+                    ),
+            )
+
+        webClient.queueResponse(response = mockableResponseFromObject(projectIDs), path = fetchGCPProjectIdsURL)
+
+        val permissionsKey1 =
+            TestIAMPermissionBody(
+                permissions =
+                    listOf(
+                        GcpIAMPermission.USE_TO_DECRYPT,
+                        GcpIAMPermission.USE_TO_ENCRYPT,
+                    ),
+            )
+
+        webClient.queueResponse(
+            response = mockableResponseFromObject(permissionsKey1),
+            path = iamPermissionURL(key1Name),
+        )
+
+        val cryptoKeys = runBlocking { googleService.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken("testToken")) }
+
+        assertEquals(1, cryptoKeys.size, "Only the key containing \"-prod-\" should be considered")
+        assertTrue(
+            cryptoKeys.any { it.projectId == key1Name && it.hasEncryptDecryptAccess },
+            "The crypto keys should include the production key ($key1Name) with encrypt and decrypt access.",
+        )
+        assertTrue(
+            cryptoKeys.all { it.projectId != key2Name },
+            "The crypto keys should not include the non-production key ($key2Name).",
+        )
+    }
+
+    @Test
+    fun `test get GCP crypto keys extra specified keys are included`() {
+        val key1Name = "key1-prod-test"
+        val key2Name = "test-key"
+        allowGCPKeyName(key2Name)
+
+        val projectIDs =
+            FetchGcpProjectIdsResponse(
+                projects =
+                    listOf(
+                        GcpProject(projectId = key1Name),
+                        GcpProject(projectId = key2Name),
+                    ),
+            )
+
+        webClient.queueResponse(response = mockableResponseFromObject(projectIDs), path = fetchGCPProjectIdsURL)
+
+        val permissionsKey1 =
+            TestIAMPermissionBody(
+                permissions =
+                    listOf(
+                        GcpIAMPermission.USE_TO_DECRYPT,
+                        GcpIAMPermission.USE_TO_ENCRYPT,
+                    ),
+            )
+
+        val permissionsKey2 =
+            TestIAMPermissionBody(permissions = listOf(GcpIAMPermission.USE_TO_DECRYPT))
+
+        webClient.queueResponse(
+            response = mockableResponseFromObject(permissionsKey1),
+            path = iamPermissionURL(key1Name),
+        )
+        webClient.queueResponse(
+            response = mockableResponseFromObject(permissionsKey2),
+            path = iamPermissionURL(key2Name),
+        )
+
+        val cryptoKeys = runBlocking { googleService.getGcpCryptoKeys(gcpAccessToken = GCPAccessToken("testToken")) }
+
+        assertEquals(2, cryptoKeys.size, "Only the key containing \"-prod-\" should be considered")
+        assertTrue(
+            cryptoKeys.any { it.projectId == key1Name && it.hasEncryptDecryptAccess },
+            "The crypto keys should include the production key ($key1Name) with encrypt and decrypt access.",
+        )
+        assertTrue(
+            cryptoKeys.any { it.projectId == key2Name && !it.hasEncryptDecryptAccess },
+            "The crypto keys should include the key ($key2Name) which has been allowed by configuration.",
         )
     }
 }

--- a/src/test/kotlin/no/risc/google/GoogleServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/google/GoogleServiceIntegrationTests.kt
@@ -1,0 +1,92 @@
+package no.risc.google
+
+import MockableResponse
+import MockableWebClient
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.risc.infra.connector.GcpCloudResourceApiConnector
+import no.risc.infra.connector.GcpKmsApiConnector
+import no.risc.infra.connector.GoogleOAuthApiConnector
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class GoogleServiceIntegrationTests {
+    private lateinit var googleService: GoogleServiceIntegration
+    private lateinit var webClient: MockableWebClient
+    private lateinit var additionalAllowedGCPKeyNames: MutableList<String>
+
+    @BeforeEach
+    fun beforeEach() {
+        additionalAllowedGCPKeyNames = mutableListOf()
+        webClient = MockableWebClient()
+        googleService =
+            GoogleServiceIntegration(
+                googleOAuthApiConnector = mockk<GoogleOAuthApiConnector>().also { every { it.webClient } returns webClient.webClient },
+                gcpCloudResourceApiConnector =
+                    mockk<GcpCloudResourceApiConnector>().also {
+                        every { it.webClient } returns
+                            webClient.webClient
+                    },
+                gcpKmsApiConnector = mockk<GcpKmsApiConnector>().also { every { it.webClient } returns webClient.webClient },
+                additionalAllowedGCPKeyNames = additionalAllowedGCPKeyNames,
+            )
+    }
+
+    @Test
+    fun `test validate access token with valid GCP access token`() {
+        webClient.queueResponse(
+            response =
+                MockableResponse(
+                    // Example response provided in the API endpoint documentation for a valid access token.
+                    // See: https://cloud.google.com/docs/authentication/token-types#access
+                    content =
+                        """
+                        {
+                          "azp": "32553540559.apps.googleusercontent.com",
+                          "aud": "32553540559.apps.googleusercontent.com",
+                          "sub": "111260650121245072906",
+                          "scope": "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/accounts.reauth",
+                          "exp": "1650056632",
+                          "expires_in": "3488",
+                          "email": "user@example.com",
+                          "email_verified": "true"
+                        }
+                        """.trimIndent(),
+                ),
+            path = "",
+        )
+
+        val isAccessTokenValid =
+            runBlocking {
+                googleService.validateAccessToken("validAccessToken")
+            }
+
+        assertTrue(
+            isAccessTokenValid,
+            "A GCP access token should be considered valid when the information returned by a call to the OAuth2 validation endpoint says it is valid.",
+        )
+    }
+
+    @Test
+    fun `test validate access token with invalid GCP access token`() {
+        // The endpoint returns a response with a 400 BAD REQUEST status when the access token is invalid.
+        webClient.queueResponse(
+            response = MockableResponse(content = "", httpStatus = HttpStatus.BAD_REQUEST),
+            path = "",
+        )
+
+        val isAccessTokenValid =
+            runBlocking {
+                googleService.validateAccessToken("invalidAccessToken")
+            }
+
+        assertFalse(
+            isAccessTokenValid,
+            "A GCP access token should not be considered valid when no information is returned on it.",
+        )
+    }
+}


### PR DESCRIPTION
Adds tests and documentation for `GoogleServiceIntegration`.

Also fixes a minor issue, where `validateAccessToken` could only return `true`. Earlier, it raised an exception if the access token was invalid. Now, `validateAccessToken` correctly returns `false` in these cases.

There are also some minor cleanup and simplification of the code in `GoogleServiceIntegration`.