### PR TITLE
Tests for initRiScService

### DIFF
--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -13,6 +13,13 @@ import org.springframework.web.reactive.function.client.awaitBodyOrNull
 class InitRiScServiceIntegration(
     private val initRiScServiceConnector: InitRiScServiceConnector,
 ) {
+    /**
+     * Generates a default RiSc based on the passed initial RiSc using the external initialise RiSc service. Returns a
+     * JSON serialised RiSc
+     *
+     * @param initialRiSc A JSON serialised RiSc to base the default RiSc on. Must include the `title` and `scope`
+     *                    fields. These are the only fields used from `initialRiSc`.
+     */
     suspend fun generateDefaultRiSc(initialRiSc: String): String =
         initRiScServiceConnector.webClient
             .post()

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -14,10 +14,10 @@ class InitRiScServiceIntegration(
     private val initRiScServiceConnector: InitRiScServiceConnector,
 ) {
     /**
-     * Generates a default RiSc based on the passed initial RiSc using the external initialise RiSc service. Returns a
-     * JSON serialised RiSc
+     * Generates a default RiSc based on the passed initial RiSc using the external initialize RiSc service. Returns a
+     * JSON serialized RiSc.
      *
-     * @param initialRiSc A JSON serialised RiSc to base the default RiSc on. Must include the `title` and `scope`
+     * @param initialRiSc A JSON serialized RiSc to base the default RiSc on. Must include the `title` and `scope`
      *                    fields. These are the only fields used from `initialRiSc`.
      */
     suspend fun generateDefaultRiSc(initialRiSc: String): String =

--- a/src/main/kotlin/no/risc/initRiSc/model/GenerateRiScRequestBody.kt
+++ b/src/main/kotlin/no/risc/initRiSc/model/GenerateRiScRequestBody.kt
@@ -1,5 +1,8 @@
 package no.risc.initRiSc.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class GenerateRiScRequestBody(
     val initialRiSc: String,
 )

--- a/src/test/kotlin/WebClientUtil.kt
+++ b/src/test/kotlin/WebClientUtil.kt
@@ -11,7 +11,7 @@ import java.net.URI
  * A data class for keeping track of a response that should be returned by the mocked web client.
  */
 data class MockableResponse(
-    val content: String,
+    val content: String?,
     val contentType: MediaType = MediaType.APPLICATION_JSON,
     val httpStatus: HttpStatus = HttpStatus.OK,
 )
@@ -84,13 +84,15 @@ class MockableWebClient {
             response = wildcardResponses.removeFirst()
         }
 
-        return Mono.just(
-            ClientResponse
-                .create(response.httpStatus)
-                .header("content-type", response.contentType.toString())
-                .body(response.content)
-                .build(),
-        )
+        var clientResponse = ClientResponse.create(response.httpStatus)
+        if (response.content != null) {
+            clientResponse =
+                clientResponse
+                    .header("Content-Type", response.contentType.toString())
+                    .body(response.content)
+        }
+
+        return Mono.just(clientResponse.build())
     }
 
     /**

--- a/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
@@ -51,7 +51,10 @@ class InitRiScServiceIntegrationTests {
 
         webClient.queueResponse(MockableResponse(content = riSc))
 
-        val response = runBlocking { initRiScServiceIntegration.generateDefaultRiSc("{}") }
+        val response =
+            runBlocking {
+                initRiScServiceIntegration.generateDefaultRiSc("""{ "title": "title", "scope": "scope"}""")
+            }
 
         assertEquals(
             riSc,

--- a/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
@@ -1,0 +1,62 @@
+package no.risc.initRiSc
+
+import MockableResponse
+import MockableWebClient
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.risc.exception.exceptions.SopsConfigGenerateFetchException
+import no.risc.infra.connector.InitRiScServiceConnector
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InitRiScServiceIntegrationTests {
+    private lateinit var initRiScServiceIntegration: InitRiScServiceIntegration
+    private lateinit var webClient: MockableWebClient
+
+    @BeforeEach
+    fun beforeEach() {
+        webClient = MockableWebClient()
+        initRiScServiceIntegration =
+            InitRiScServiceIntegration(
+                initRiScServiceConnector = mockk<InitRiScServiceConnector>().also { every { it.webClient } returns webClient.webClient },
+            )
+    }
+
+    @Test
+    fun `test generate default RiSc throws SopsConfigGenerateFetchException when no content is received`() {
+        webClient.queueResponse(MockableResponse(content = null))
+
+        assertThrows<SopsConfigGenerateFetchException> {
+            runBlocking {
+                initRiScServiceIntegration.generateDefaultRiSc("")
+            }
+        }
+    }
+
+    @Test
+    fun `test generate default RiSc returns generated RiSc string`() {
+        val riSc =
+            """
+            {
+              "schemaVersion": "4.0",
+              "title": "Transformasjon",
+              "scope": "Sikkerhet av backend.",
+              "valuations": [],
+              "scenarios": []
+            }
+            """.trimIndent()
+
+        webClient.queueResponse(MockableResponse(content = riSc))
+
+        val response = runBlocking { initRiScServiceIntegration.generateDefaultRiSc("{}") }
+
+        assertEquals(
+            riSc,
+            response,
+            "The returned default RiSc should be equivalent to the one returned from the initialize-risc API endpoint.",
+        )
+    }
+}


### PR DESCRIPTION
Changes the code for initRiScService from FasterXML Jackson to `kotlinx-serialization`. Also introduces tests for this integration.