### PR TITLE
Update Pharos to version 0.3.2 

### DIFF
--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -147,11 +147,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Run Pharos"
-        uses: kartverket/pharos@v0.3.1
+        uses: kartverket/pharos@v0.3.2
         with:
           image_url: ${{ needs.build.outputs.image_url }}
           # Backstage config files are misclassified as kubernetes config files, resulting in false security issues
           skip_dirs: '.security/.backstage/component,.security/.backstage/system'
+          skip_files: 'catalog-info.yaml,.security/catalog-info.yaml'
 
   dev-deploy-argo:
     name: Deploy to atgcp1-dev


### PR DESCRIPTION
Updates Pharos to version 0.3.2. This version adds a `skip_files` configuration variable, which allows the listed files to be skipped for code scanning. As described in #365, `catalog-info.yaml` and `.security/catalog-info.yaml` er misclassified as Kubernetes config files. Therefore, they are now configured to be skipped by Pharos.

Closes #365.