### PR TITLE
Fix for DTO related bug introduced in #417

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -49,11 +49,17 @@ class GithubHelper(
         draftBranch: String = riScId,
     ): String = "/$owner/$repository/contents/$riScFolderPath/$riScId.$filenamePostfix.yaml?ref=$draftBranch"
 
-    fun uriToGetCommitStatus(
+    /**
+     * Constructs a URI to get the last commit on a provided branch.
+     *
+     * @see <a href="https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit">The get a
+     *      commit API reference</a>
+     */
+    fun uriToGetLastCommitOnBranch(
         owner: String,
         repository: String,
         branchName: String,
-    ): String = "/$owner/$repository/commits/$branchName/status"
+    ): String = "/$owner/$repository/commits/heads/$branchName"
 
     fun uriToCreateNewBranch(
         owner: String,


### PR DESCRIPTION
A bug was introduced in #417 when DTOs were merged. The method `fetchLatestShaForDefaultBranch` now used a DTO for file requests to a commit based endpoint. This PR fixes the bug by using the appropriate commit DTO. Additionally, the GitHub API endpoint used is exchange for a more appropriate one.