### PR TITLE
Document and simplify GithubConnector

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -400,7 +400,7 @@ class GithubConnector(
             coroutineScope {
                 val prExistsDeferred =
                     async {
-                        pullRequestForRiScExists(
+                        doesPullRequestForRiScExists(
                             owner = owner,
                             repository = repository,
                             riScId = riScId,
@@ -501,6 +501,15 @@ class GithubConnector(
             }
         }
 
+    /**
+     * Finds the SHA for the last version of the file associated with the given RiSc on the draft branch of that
+     * RiSc (`riScId`).
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param riScId The ID of the RiSc.
+     * @param accessToken The GitHub access token to make the request with.
+     */
     private suspend fun getSHAForExistingRiScDraftOrNull(
         owner: String,
         repository: String,
@@ -513,6 +522,14 @@ class GithubConnector(
         ).awaitBodyOrNull<GithubFileDTO>()?.sha
     }
 
+    /**
+     * Finds the SHA for the last published version of the file associated with the given RiSc.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param riScId The ID of the RiSc.
+     * @param accessToken The GitHub access token to make the request with.
+     */
     private suspend fun getSHAForPublishedRiScOrNull(
         owner: String,
         repository: String,
@@ -525,7 +542,16 @@ class GithubConnector(
         ).awaitBodyOrNull<GithubFileDTO>()?.sha
     }
 
-    private suspend fun pullRequestForRiScExists(
+    /**
+     * Determines if there exists a pull request for merging the draft branch of the given RiSc (`riScId`) into another
+     * branch.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param riScId The ID of the RiSc.
+     * @param accessToken The GitHub access token to make the request with.
+     */
+    private suspend fun doesPullRequestForRiScExists(
         owner: String,
         repository: String,
         riScId: String,
@@ -601,6 +627,13 @@ class GithubConnector(
         ).awaitBodyOrNull<String>()
     }
 
+    /**
+     * Fetches all open pull requests in the repository.
+     *
+     * @param owner The owner (user/organisation) of the repository.
+     * @param repository The name of the repository to make the branch in,
+     * @param accessToken The GitHub access token to use for authorization.
+     */
     suspend fun fetchAllPullRequests(
         owner: String,
         repository: String,
@@ -892,6 +925,11 @@ class GithubConnector(
             it.header("Content-Type", "application/json").body(Mono.just(content), String::class.java)
         })
 
+    /**
+     * Maps exceptions returned by a web client to more descriptive GitHub statuses.
+     *
+     * @param e: The exception to map
+     */
     private fun mapWebClientExceptionToGithubStatus(e: Exception): GithubStatus =
         if (e !is WebClientResponseException) {
             GithubStatus.InternalError

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -29,6 +29,7 @@ import no.risc.risc.RiScStatus
 import no.risc.risc.models.UserInfo
 import no.risc.utils.decodeBase64
 import no.risc.utils.encodeBase64
+import no.risc.utils.tryOrDefault
 import no.risc.utils.tryOrNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -207,7 +208,7 @@ class GithubConnector(
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
-        try {
+        tryOrDefault(default = emptyList()) {
             getGithubResponse(uri = githubHelper.uriToFindRiScFiles(owner, repository), accessToken = accessToken)
                 .awaitBody<List<GithubFileDTO>>()
                 // All RiSc files end in ".<filenamePostfix>.yaml".
@@ -219,8 +220,6 @@ class GithubConnector(
                         status = RiScStatus.Published,
                     )
                 }
-        } catch (e: Exception) {
-            emptyList()
         }
 
     /**
@@ -235,7 +234,7 @@ class GithubConnector(
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
-        try {
+        tryOrDefault(default = emptyList()) {
             getGithubResponse(
                 uri = githubHelper.uriToFetchAllPullRequests(owner = owner, repository = repository),
                 accessToken = accessToken,
@@ -249,8 +248,6 @@ class GithubConnector(
                     )
                     // Every RiSc identifier starts with "<filenamePrefix>-".
                 }.filter { it.id.startsWith("$filenamePrefix-") }
-        } catch (e: Exception) {
-            emptyList()
         }
 
     /**
@@ -266,7 +263,7 @@ class GithubConnector(
         repository: String,
         accessToken: String,
     ): List<RiScIdentifier> =
-        try {
+        tryOrDefault(default = emptyList()) {
             getGithubResponse(
                 // This URI retrieves only branches that start with "<filenamePrefix>-"
                 uri = githubHelper.uriToFindAllRiScBranches(owner = owner, repository = repository),
@@ -274,8 +271,6 @@ class GithubConnector(
             ).awaitBody<List<GithubReferenceObjectDTO>>()
                 // Want only the part after the last "/" in the branch path, ignoring "origin/", etc.
                 .map { RiScIdentifier(id = it.ref.substringAfterLast('/'), status = RiScStatus.Draft) }
-        } catch (e: Exception) {
-            emptyList()
         }
 
     internal suspend fun fetchLastPublishedRiScDateAndCommitNumber(
@@ -583,13 +578,11 @@ class GithubConnector(
         repository: String,
         accessToken: String,
     ): List<GithubPullRequestObject> =
-        try {
+        tryOrDefault(default = emptyList()) {
             getGithubResponse(
                 uri = githubHelper.uriToFetchAllPullRequests(owner = owner, repository = repository),
                 accessToken = accessToken,
             ).awaitBody<List<GithubPullRequestObject>>()
-        } catch (e: Exception) {
-            emptyList()
         }
 
     private suspend fun fetchCommitsSinceLastCommit(
@@ -599,7 +592,7 @@ class GithubConnector(
         riScId: String,
         since: String,
     ): List<GithubCommitObject> =
-        try {
+        tryOrDefault(default = emptyList()) {
             getGithubResponse(
                 uri =
                     githubHelper.uriToFetchAllCommitsOnBranchSince(
@@ -610,8 +603,6 @@ class GithubConnector(
                     ),
                 accessToken = accessToken,
             ).awaitBodyOrNull<List<GithubCommitObject>>() ?: emptyList()
-        } catch (e: Exception) {
-            emptyList()
         }
 
     private suspend fun fetchLatestCommitTimestampOnDefault(

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -619,9 +619,9 @@ class GithubConnector(
             accessToken = accessToken,
             content =
                 githubHelper
-                    .bodyToCreateNewBranchFromDefault(
+                    .bodyToCreateNewBranch(
                         branchName = newBranchName,
-                        latestShaAtDefault = latestShaForDefaultBranch,
+                        shaToBranchFrom = latestShaForDefaultBranch,
                     ).toContentBody(),
             method = HttpMethod.POST,
         ).awaitBodyOrNull<String>()

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -14,46 +14,115 @@ class GithubHelper(
     @Value("\${filename.postfix}") private val filenamePostfix: String,
     @Value("\${github.repository.risc-folder-path}") private val riScFolderPath: String,
 ) {
-    fun uriToFindRiScFiles(
-        owner: String,
-        repository: String,
-    ): String = "/$owner/$repository/contents/$riScFolderPath"
+    private fun riscPath(riScId: String): String = "$riScFolderPath/$riScId.$filenamePostfix.yaml"
 
+    /**
+     * Constructs a URI for performing file/directory operations (retrieval and update). If no branch is provided, then
+     * the default branch is considered.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param path The path of the file/directory to consider
+     * @param branch The branch to perform the operations on.
+     * @see <a href="https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content">The
+     *      get repository content API documentation</a>
+     */
     fun repositoryContentsUri(
         owner: String,
         repository: String,
         path: String,
         branch: String? = null,
-    ): String = branch?.let { "/$owner/$repository/contents/$path?ref=$branch" } ?: "/$owner/$repository/contents/$path"
+        // ): String = branch?.let { "/$owner/$repository/contents/$path?ref=$branch" } ?: "/$owner/$repository/contents/$path"
+    ): String = "/$owner/$repository/contents/$path${branch?.let { "?ref=$branch" } ?: ""}"
 
+    /**
+     * Constructs a URI to get all RiSc files in the given repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content">The
+     *      get repository content API documentation</a>
+     */
+    fun uriToFindRiScFiles(
+        owner: String,
+        repository: String,
+    ): String = repositoryContentsUri(owner = owner, repository = repository, path = riScFolderPath)
+
+    /**
+     * Constructs a URI to get the contents of a specific RiSc.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param id The id of the RiSc to get the contents for.
+     * @see <a href="https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content">The
+     *      get repository content API documentation</a>
+     */
     fun uriToFindRiSc(
         owner: String,
         repository: String,
         id: String,
-    ): String = "/$owner/$repository/contents/$riScFolderPath/$id.$filenamePostfix.yaml"
+    ): String =
+        repositoryContentsUri(
+            owner = owner,
+            repository = repository,
+            path = riscPath(id),
+        )
 
+    /**
+     * Constructs a URI to get the contents of a specific RiSc on its draft branch.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param id The id of the RiSc to get the contents for.
+     * @see <a href="https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content">The
+     *      get repository content API documentation</a>
+     */
+    fun uriToFindRiScOnDraftBranch(
+        owner: String,
+        repository: String,
+        riScId: String,
+    ): String =
+        repositoryContentsUri(
+            owner = owner,
+            repository = repository,
+            path = riscPath(riScId),
+            branch = riScId,
+        )
+
+    /**
+     * Constructs a URI to retrieve all draft branches for RiScs.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references">The list
+     *      matching references API documentation</a>
+     */
     fun uriToFindAllRiScBranches(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository/git/matching-refs/heads/$filenamePrefix-"
 
+    /**
+     * Constructs a URI to retrieve information about the provided repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository">The get a
+     *      repository API documentation</a>
+     */
     fun uriToGetRepositoryInfo(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository"
 
-    fun uriToFindRiScOnDraftBranch(
-        owner: String,
-        repository: String,
-        riScId: String,
-        draftBranch: String = riScId,
-    ): String = "/$owner/$repository/contents/$riScFolderPath/$riScId.$filenamePostfix.yaml?ref=$draftBranch"
-
     /**
      * Constructs a URI to get the last commit on a provided branch.
      *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param branchName The name of the branch.
      * @see <a href="https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit">The get a
-     *      commit API reference</a>
+     *      commit API documentation</a>
      */
     fun uriToGetLastCommitOnBranch(
         owner: String,
@@ -61,38 +130,83 @@ class GithubHelper(
         branchName: String,
     ): String = "/$owner/$repository/commits/heads/$branchName"
 
+    /**
+     * Constructs a URI to create new branches in the provided repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference">The create a
+     *      reference API documentation</a>
+     */
     fun uriToCreateNewBranch(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository/git/refs"
 
+    /**
+     * Constructs a URI to fetch all pull requests in the repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests">The list pull
+     *      requests API documentation</a>
+     */
     fun uriToFetchAllPullRequests(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository/pulls"
 
+    /**
+     * Constructs a URI to create a pull request in the repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @see <a href="https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request">The create
+     *      a pull request API documentation</a>
+     */
     fun uriToCreatePullRequest(
         owner: String,
         repository: String,
     ): String = "/$owner/$repository/pulls"
 
+    /**
+     * Constructs a URI to create a pull request in the repository.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to consider.
+     * @param pullRequestNumber The id of the pull request to edit
+     * @see <a href="https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#update-a-pull-request">The update
+     *      a pull request API documentation</a>
+     */
     fun uriToEditPullRequest(
         owner: String,
         repository: String,
         pullRequestNumber: Int,
     ): String = "/$owner/$repository/pulls/$pullRequestNumber"
 
+    /**
+     * The default request body used for closing a pull request.
+     *
+     * @see uriToEditPullRequest
+     */
     fun bodyToClosePullRequest(): String =
         "{ \"title\":\"Closed\", \"body\": \"The PR was closed when risk scorecard was updated. " +
             "New approval from risk owner is required.\",  \"state\": \"closed\"}"
 
-    fun bodyToCreateNewBranchFromDefault(
+    /**
+     * Constructs a request body to create a new branch with.
+     *
+     * @param branchName The name of the new branch.
+     * @param shaToBranchFrom The SHA of the commit to branch out from.
+     * @see uriToCreateNewBranch
+     */
+    fun bodyToCreateNewBranch(
         branchName: String,
-        latestShaAtDefault: String,
+        shaToBranchFrom: String,
     ): GithubCreateNewBranchPayload =
         GithubCreateNewBranchPayload(
             nameOfNewBranch = "refs/heads/$branchName",
-            shaOfLatestDefault = latestShaAtDefault,
+            shaToBranchFrom = shaToBranchFrom,
         )
 
     /**
@@ -125,7 +239,7 @@ class GithubHelper(
             }${
                 since?.let { "since=$since&" } ?: ""
             }${
-                riScId?.let { "path=$riScFolderPath/$riScId.$filenamePostfix.yaml" } ?: ""
+                riScId?.let { "path=${riscPath(riScId)}" } ?: ""
             }"
         }
 }

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -14,6 +14,11 @@ class GithubHelper(
     @Value("\${filename.postfix}") private val filenamePostfix: String,
     @Value("\${github.repository.risc-folder-path}") private val riScFolderPath: String,
 ) {
+    /**
+     * Constructs the file path to the file for the given RiSc.
+     *
+     * @param riScId The ID of the RiSc.
+     */
     private fun riscPath(riScId: String): String = "$riScFolderPath/$riScId.$filenamePostfix.yaml"
 
     /**

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -95,39 +95,37 @@ class GithubHelper(
             shaOfLatestDefault = latestShaAtDefault,
         )
 
-    fun uriToFetchAllCommitsOnBranchSince(
-        owner: String,
-        repository: String,
-        branchName: String,
-        since: String,
-    ): String = "/$owner/$repository/commits?sha=$branchName&since=$since"
-
-    fun uriToFetchCommit(
-        owner: String,
-        repository: String,
-        riScId: String,
-        branch: String,
-    ): String = "/$owner/$repository/commits?sha=$branch&path=$riScFolderPath/$riScId.$filenamePostfix.yaml"
-
+    /**
+     * Produces a URL to retrieve commits from the given repository (`owner/repository`). Commits are by default
+     * retrieved for the default branch of the repository, unless a specific branch is given. Similarly, commits are
+     * retrieved for the entire git history, unless a specific start date-time is given. If a RiSc ID is given, only
+     * commits that change the content file for that RiSc are retrieved.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to retrieve commits from.
+     * @param riScId The RiSc to retrieve commits for. Only applicable if given (`!= null`)
+     * @param branch The branch to retrieve commits on. If not given (`!= null`), the default branch is used.
+     * @param since The date-time to retrieve commits since.
+     *
+     * @see <a href="https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits">List commits
+     *      API documentation</a>
+     */
     fun uriToFetchCommits(
         owner: String,
         repository: String,
         riScId: String? = null,
         branch: String? = null,
+        since: OffsetDateTime? = null,
     ): String =
-        if (branch == null && riScId == null) {
+        if (branch == null && riScId == null && since == null) {
             "/$owner/$repository/commits"
         } else {
             "/$owner/$repository/commits?${
-                branch?.let {
-                    "sha=$branch"
-                } ?: ""
-            }&${riScId?.let { "path=$riScFolderPath/$riScId.$filenamePostfix.yaml" } ?: ""}"
+                branch?.let { "sha=$branch&" } ?: ""
+            }${
+                since?.let { "since=$since&" } ?: ""
+            }${
+                riScId?.let { "path=$riScFolderPath/$riScId.$filenamePostfix.yaml" } ?: ""
+            }"
         }
-
-    fun uriToFetchCommitsSince(
-        owner: String,
-        repository: String,
-        since: OffsetDateTime,
-    ): String = "/$owner/$repository/commits?since=$since"
 }

--- a/src/main/kotlin/no/risc/github/models/GithubRequest.kt
+++ b/src/main/kotlin/no/risc/github/models/GithubRequest.kt
@@ -70,7 +70,7 @@ data class GithubCreateNewPullRequestPayload(
 @Serializable
 data class GithubCreateNewBranchPayload(
     val nameOfNewBranch: String,
-    val shaOfLatestDefault: String,
+    val shaToBranchFrom: String,
 ) {
-    fun toContentBody(): String = "{ \"ref\":\"$nameOfNewBranch\", \"sha\": \"$shaOfLatestDefault\" }"
+    fun toContentBody(): String = "{ \"ref\":\"$nameOfNewBranch\", \"sha\": \"$shaToBranchFrom\" }"
 }

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -615,7 +615,7 @@ class RiScService(
                     riScId = riScId,
                     fileContent = encryptedData,
                     requiresNewApproval = content.isRequiresNewApproval,
-                    accessTokens = accessTokens,
+                    gitHubAccessToken = accessTokens.githubAccessToken,
                     userInfo = content.userInfo,
                     defaultBranch = defaultBranch,
                 )

--- a/src/main/kotlin/no/risc/utils/Utils.kt
+++ b/src/main/kotlin/no/risc/utils/Utils.kt
@@ -46,9 +46,18 @@ fun generateRandomAlphanumericString(
  * Returns the result of the provided function, unless the provided function throws an exception. If an exception is
  * thrown, then null is returned.
  */
-inline fun <T> tryOrNull(func: () -> T?) =
+inline fun <T> tryOrNull(func: () -> T?): T? = tryOrDefault(default = null, func = func)
+
+/**
+ * Returns the result of the provided function, unless the provided function throws an exception. If an exception is
+ * thrown, then the provided default value is returned.
+ */
+inline fun <T> tryOrDefault(
+    default: T,
+    func: () -> T,
+): T =
     try {
         func()
     } catch (_: Exception) {
-        null
+        default
     }


### PR DESCRIPTION
Documents and slightly simplifies the code related to GithubConnector:

- Provides docstrings with references to relevant parts of the GitHub API documentation.
- Introduces `tryOrDefault` in a similar way as `tryOrNull`
- Small changes to standardise implementations
- Simplifies and reuses code in `GithubHelper` for constructing URLs.
- Simplifies `GithubConnector.mapWebClientExceptionToGithubStatus`
- Reorganises the order of some functions in `GithubHelper, to group functions by API endpoint (makes the diff look a bit bad).