### PR TITLE
Add health check in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,7 @@ COPY --chmod=0755 docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["java", "-jar", "/app/backend.jar"]
+
+# Use the health endpoint of the application to provide information through docker about the health state of the application
+HEALTHCHECK --start-period=30s --start-interval=10s --interval=5m \
+    CMD wget -O - --quiet --tries=1 http://localhost:8081/actuator/health | grep UP || exit 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
-        because("Provides endpoints for health and event monitoring that are used in SKIP.")
+        because("Provides endpoints for health and event monitoring that are used in SKIP and Docker.")
     }
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$fasterXmlJacksonVersion")


### PR DESCRIPTION
Adds a health check to the docker container, to allow docker to know if the application is healthy. 

Fixes [code scanning issue 288](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/code-scanning/288).