### PR TITLE
Tests for pull request related code in GithubConnector

### DIFF
--- a/src/main/kotlin/no/risc/github/models/GithubRequest.kt
+++ b/src/main/kotlin/no/risc/github/models/GithubRequest.kt
@@ -53,12 +53,15 @@ data class Author(
 data class GithubCreateNewPullRequestPayload(
     val title: String,
     val body: String,
-    val repositoryOwner: String,
-    val branch: String,
-    val baseBranch: String,
+    val head: String,
+    val base: String,
 ) {
-    fun toContentBody(): String =
-        "{ \"title\":\"$title\", \"body\": \"$body\", \"head\": \"$repositoryOwner:$branch\", \"base\": \"$baseBranch\" }"
+    constructor(title: String, body: String, repositoryOwner: String, branch: String, baseBranch: String) : this(
+        title = title,
+        body = body,
+        head = "$repositoryOwner:$branch",
+        base = baseBranch,
+    )
 }
 
 /**

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -11,18 +11,11 @@ import no.risc.github.models.GithubFileDTO
 import no.risc.github.models.GithubPullRequestBranch
 import no.risc.github.models.GithubPullRequestObject
 import no.risc.github.models.GithubReferenceObjectDTO
-
-<<<<<<< HEAD
 import no.risc.github.models.GithubRepositoryDTO
 import no.risc.github.models.GithubRepositoryPermissions
 import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.risc.RiScIdentifier
-
-=======
-import no.risc.github.models.GithubStatus
-
->>>>>>> aefff86 (Add tests for fetch RiSc content)
 import no.risc.risc.RiScStatus
 import no.risc.utils.encodeBase64
 import no.risc.utils.generateRandomAlphanumericString

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -2,11 +2,14 @@ package no.risc.github
 
 import MockableResponse
 import MockableWebClient
+import deserializeContent
 import io.mockk.every
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import mockableResponseFromObject
+import no.risc.exception.exceptions.CreatePullRequestException
 import no.risc.exception.exceptions.PermissionDeniedOnGitHubException
+import no.risc.github.models.GithubCreateNewPullRequestPayload
 import no.risc.github.models.GithubFileDTO
 import no.risc.github.models.GithubPullRequestBranch
 import no.risc.github.models.GithubPullRequestObject
@@ -17,6 +20,7 @@ import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.risc.RiScIdentifier
 import no.risc.risc.RiScStatus
+import no.risc.risc.models.UserInfo
 import no.risc.utils.encodeBase64
 import no.risc.utils.generateRandomAlphanumericString
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -517,6 +521,70 @@ class GithubConnectorTests {
             val result = runBlocking { githubConnector.fetchAllPullRequests(owner, repository, "access token") }
 
             assertEquals(0, result.size, "On an error, an empty list should be returned.")
+        }
+
+        @Test
+        fun `test create pull request for RiSc`() {
+            val riScId = "aaaab"
+            val baseBranch = "main"
+
+            val pullRequest =
+                GithubPullRequestObject(
+                    url = "https://api.github.com/repos/$owner/$repository/pulls/29",
+                    title = "Updated risk scorecard",
+                    createdAt = OffsetDateTime.now(),
+                    head = GithubPullRequestBranch("risc-$riScId"),
+                    base = GithubPullRequestBranch("main"),
+                    number = 37,
+                )
+
+            webClient.queueResponse(
+                response = mockableResponseFromObject(pullRequest),
+            )
+
+            val result =
+                runBlocking {
+                    githubConnector.createPullRequestForRiSc(
+                        owner = owner,
+                        repository = repository,
+                        riScId = riScId,
+                        requiresNewApproval = true,
+                        gitHubAccessToken = "access token",
+                        userInfo = UserInfo(name = "Kari Nordmann", email = "kari.nordmann@test.com"),
+                        baseBranch = baseBranch,
+                    )
+                }
+
+            assertEquals(pullRequest, result, "The create pull request should be returned.")
+
+            val request = webClient.getNextRequest()
+
+            val requestContent = request.deserializeContent<GithubCreateNewPullRequestPayload>()
+
+            assertEquals(baseBranch, requestContent.base, "PR should be to the provided base branch.")
+            assertEquals("$owner:$riScId", requestContent.head, "PR should be from the RiSc branch.")
+        }
+
+        @Test
+        fun `test create pull request for RiSc throws exception on error`() {
+            webClient.queueResponse(
+                response = MockableResponse(content = null, httpStatus = HttpStatus.BAD_REQUEST),
+                path = pathToPullRequestEndpoint,
+            )
+
+            assertThrows<CreatePullRequestException> {
+                runBlocking {
+                    githubConnector.createPullRequestForRiSc(
+                        owner = owner,
+                        repository = repository,
+                        riScId = "aaaaa",
+                        requiresNewApproval = false,
+                        gitHubAccessToken = "access token",
+                        userInfo = UserInfo(name = "Ola Nordmann", email = "ola.nordmann@test.com"),
+                        baseBranch = "main",
+                    )
+                }
+            }
         }
     }
 }

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -11,11 +11,18 @@ import no.risc.github.models.GithubFileDTO
 import no.risc.github.models.GithubPullRequestBranch
 import no.risc.github.models.GithubPullRequestObject
 import no.risc.github.models.GithubReferenceObjectDTO
+
+<<<<<<< HEAD
 import no.risc.github.models.GithubRepositoryDTO
 import no.risc.github.models.GithubRepositoryPermissions
 import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.risc.RiScIdentifier
+
+=======
+import no.risc.github.models.GithubStatus
+
+>>>>>>> aefff86 (Add tests for fetch RiSc content)
 import no.risc.risc.RiScStatus
 import no.risc.utils.encodeBase64
 import no.risc.utils.generateRandomAlphanumericString


### PR DESCRIPTION
Adds tests for pull request related code in GithubConnector:

- Tests `GithubConnector.fetchAllPullRequests`
- Tests `GithubConnector.createPullRequestForRiSc`
- Adds support for extracting the body of a request in the test utility `MockableWebClient`
- Moves `GithubCreateNewPullRequestPayload` from a custom serialiser to using `kotlinx-serialization`