### PR TITLE
Tests for GithubConnector.putFileRequestToGithub

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -819,8 +819,8 @@ class GithubConnector(
                                 filePath = filePath,
                                 branch = branch,
                             )?.sha,
-                        branchName = branch,
-                    ).toContentBody(),
+                        branch = branch,
+                    ),
                 method = HttpMethod.PUT,
             )
         } catch (e: WebClientResponseException.BadRequest) {

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -37,7 +37,6 @@ class GithubHelper(
         repository: String,
         path: String,
         branch: String? = null,
-        // ): String = branch?.let { "/$owner/$repository/contents/$path?ref=$branch" } ?: "/$owner/$repository/contents/$path"
     ): String = "/$owner/$repository/contents/$path${branch?.let { "?ref=$branch" } ?: ""}"
 
     /**

--- a/src/main/kotlin/no/risc/github/models/GithubRequest.kt
+++ b/src/main/kotlin/no/risc/github/models/GithubRequest.kt
@@ -1,8 +1,8 @@
 package no.risc.github.models
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.risc.utils.KDateSerializer
-import java.text.SimpleDateFormat
 import java.util.Date
 
 /**
@@ -16,15 +16,10 @@ data class GithubWriteToFilePayload(
     val message: String,
     val content: String,
     val sha: String? = null,
-    val branchName: String,
+    val branch: String,
+    @SerialName("committer")
     val author: Author? = null,
-) {
-    fun toContentBody(): String =
-        "{\"message\": \"$message\", \"content\": \"$content\", \"branch\": \"$branchName\"" +
-            (author?.let { ", \"committer\": ${author.toJSONString()}" } ?: "") +
-            (sha?.let { ", \"sha\": \"$sha\"" } ?: "") +
-            "}"
-}
+)
 
 /**
  * The author to create/update a file as.
@@ -37,11 +32,7 @@ data class Author(
     val email: String?,
     @Serializable(KDateSerializer::class)
     val date: Date,
-) {
-    private fun formattedDate(): String = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(date)
-
-    fun toJSONString(): String = "{ \"name\":\"${name}\", \"email\":\"${email}\", \"date\":\"${formattedDate()}\" }"
-}
+)
 
 /**
  * For use with GitHub's create pull request API endpoint.

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -805,7 +805,11 @@ class GithubConnectorTests {
                     branch = branch,
                 )
 
-            assertEquals(responseString, response)
+            assertEquals(
+                responseString,
+                response,
+                "The file content provided should be equal to the one returned by the GitHub API.",
+            )
 
             // Ignore file info request
             webClient.getNextRequest()
@@ -850,7 +854,11 @@ class GithubConnectorTests {
                     branch = branch,
                 )
 
-            assertEquals(responseString, response)
+            assertEquals(
+                responseString,
+                response,
+                "The file content provided should be equal to the one returned by the GitHub API.",
+            )
 
             // Ignore file info request
             webClient.getNextRequest()

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -20,7 +20,9 @@ import no.risc.github.models.GithubReferenceObjectDTO
 import no.risc.github.models.GithubRepositoryDTO
 import no.risc.github.models.GithubRepositoryPermissions
 import no.risc.github.models.GithubStatus
+import no.risc.github.models.GithubWriteToFilePayload
 import no.risc.infra.connector.models.GitHubPermission
+import no.risc.infra.connector.models.GithubAccessToken
 import no.risc.risc.LastPublished
 import no.risc.risc.RiScIdentifier
 import no.risc.risc.RiScStatus
@@ -35,7 +37,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.awaitBody
 import java.time.OffsetDateTime
 
 class GithubConnectorTests {
@@ -729,6 +733,168 @@ class GithubConnectorTests {
             val lastPublished = fetchLastPublished(riScId)
 
             assertNull(lastPublished, "If calls to the GitHub API fail, null should be returned.")
+        }
+    }
+
+    @Nested
+    inner class TestPutFileRequest {
+        private fun fileURL(
+            path: String,
+            branch: String,
+        ) = "/$owner/$repository/contents/$path?ref=$branch"
+
+        /* A response string mimicking parts of the response from the GitHub API. The response is not processed in the
+           application beyond a string. There is thus no datatype to use for the answer. */
+        private fun constructResponseString(path: String) =
+            """
+            {
+                "content": {
+                    "name": "${path.split("/").last()}",
+                    "path": "$path",
+                    "sha": "${randomSHA()}",
+                },
+                "commit": {
+                    "sha": "${randomSHA()}",
+                }
+            }
+            """.trimIndent()
+
+        private fun putFileRequest(
+            filePath: String,
+            commitMessage: String,
+            content: String,
+            branch: String,
+        ): String =
+            runBlocking {
+                githubConnector
+                    .putFileRequestToGithub(
+                        repositoryOwner = owner,
+                        repositoryName = repository,
+                        gitHubAccessToken = GithubAccessToken("accessToken"),
+                        filePath = filePath,
+                        message = commitMessage,
+                        content = content,
+                        branch = branch,
+                    ).awaitBody<String>()
+            }
+
+        @Test
+        fun `test file creation with put file request`() {
+            val filePath = pathToRiSC("aaaaa")
+            val branch = "main"
+
+            // The file does not exist, so there is no file contents available.
+            webClient.queueResponse(
+                response = MockableResponse(content = null, httpStatus = HttpStatus.NOT_FOUND),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.GET,
+            )
+
+            val responseString = constructResponseString(filePath)
+            webClient.queueResponse(
+                response = MockableResponse(content = responseString),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.PUT,
+            )
+
+            val response =
+                putFileRequest(
+                    filePath = filePath,
+                    commitMessage = "Creating new RiSc",
+                    content = """{ "schemaVersion": "4.0" }""",
+                    branch = branch,
+                )
+
+            assertEquals(responseString, response)
+
+            // Ignore file info request
+            webClient.getNextRequest()
+
+            val requestBody = webClient.getNextRequest().deserializeContent<GithubWriteToFilePayload>()
+            assertNull(requestBody.sha, "The SHA should be null if the file does not already exist.")
+        }
+
+        @Test
+        fun `test file update with put file request`() {
+            val filePath = pathToRiSC("aaaab")
+            val branch = "default"
+
+            val fileSHA = randomSHA()
+
+            // The file already exists, so any GET request for the file should return information about it.
+            webClient.queueResponse(
+                response =
+                    mockableResponseFromObject(
+                        GithubFileDTO(
+                            content = """{ "schemaVersion": "4.0" }""",
+                            sha = fileSHA,
+                            name = filePath.split("/").last(),
+                        ),
+                    ),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.GET,
+            )
+
+            val responseString = constructResponseString(filePath)
+            webClient.queueResponse(
+                response = MockableResponse(content = responseString),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.PUT,
+            )
+
+            val response =
+                putFileRequest(
+                    filePath = filePath,
+                    commitMessage = "Updating RiSc",
+                    content = """{ "schemaVersion": "4.1" }""",
+                    branch = branch,
+                )
+
+            assertEquals(responseString, response)
+
+            // Ignore file info request
+            webClient.getNextRequest()
+
+            val requestBody = webClient.getNextRequest().deserializeContent<GithubWriteToFilePayload>()
+            assertEquals(fileSHA, requestBody.sha, "The SHA should be equal to the file SHA if the file already exist.")
+        }
+
+        @Test
+        fun `test put file request throws exception on error`() {
+            val filePath = pathToRiSC("aaaac")
+            val branch = "dev"
+
+            val fileSHA = randomSHA()
+
+            // The file already exists, so any GET request for the file should return information about it.
+            webClient.queueResponse(
+                response =
+                    mockableResponseFromObject(
+                        GithubFileDTO(
+                            content = """{ "schemaVersion": "4.0" }""",
+                            sha = fileSHA,
+                            name = filePath.split("/").last(),
+                        ),
+                    ),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.GET,
+            )
+
+            // Want to check error handling on API errors.
+            webClient.queueResponse(
+                response = MockableResponse(content = null, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+                path = fileURL(filePath, branch),
+                method = HttpMethod.PUT,
+            )
+
+            assertThrows<Exception> {
+                putFileRequest(
+                    filePath = filePath,
+                    commitMessage = "Updating RiSc",
+                    content = """{ "schemaVersion": "4.1" }""",
+                    branch = branch,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds tests for `GithubConnector.putFileRequestToGithub`.
- Updates `WebClientUtil` to also allow matches on specific HTTP methods.
- Uses `kotlinx.serialization` JSON serialization instead of custom JSON serialization methods for related DTOs (`GithubRequest.GithubWriteToFilePayload` and `GithubRequest.Author`).