### PR TITLE
Remove remaining usage of FasterXML Jackson

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ val springSecurityVersion = "6.4.5"
 val kotlinxSerializationVersion = "1.8.1"
 val kotlinxCoroutinesVersion = "1.10.2"
 val micrometerVersion = "1.15.0"
-val fasterXmlJacksonVersion = "2.19.0"
 val jsonSchemaValidatorVersion = "1.5.6"
 val nimbusdsVersion = "10.3"
 val bouncyCastleVersion = "1.80"
@@ -72,7 +71,6 @@ dependencies {
         because("Provides endpoints for health and event monitoring that are used in SKIP and Docker.")
     }
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$fasterXmlJacksonVersion")
     implementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
 
     testImplementation(platform("org.junit:junit-bom:$junitVersion")) {

--- a/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServiceIntegration.kt
@@ -1,5 +1,6 @@
 package no.risc.encryption
 
+import no.risc.encryption.models.EncryptionRequest
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.infra.connector.CryptoServiceConnector
@@ -12,13 +13,6 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.awaitBody
 import kotlin.math.min
-
-data class EncryptionRequest(
-    val text: String,
-    val config: SopsConfig,
-    val gcpAccessToken: String,
-    val riScId: String,
-)
 
 @Component
 class CryptoServiceIntegration(

--- a/src/main/kotlin/no/risc/encryption/models/EncryptionRequest.kt
+++ b/src/main/kotlin/no/risc/encryption/models/EncryptionRequest.kt
@@ -1,0 +1,12 @@
+package no.risc.encryption.models
+
+import kotlinx.serialization.Serializable
+import no.risc.risc.models.SopsConfig
+
+@Serializable
+data class EncryptionRequest(
+    val text: String,
+    val config: SopsConfig,
+    val gcpAccessToken: String,
+    val riScId: String,
+)

--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -14,11 +14,11 @@ import no.risc.exception.exceptions.RiScNotValidOnUpdateException
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.exception.exceptions.UpdatingRiScException
-import no.risc.risc.ContentStatus
-import no.risc.risc.DecryptionFailure
-import no.risc.risc.ProcessRiScResultDTO
-import no.risc.risc.ProcessingStatus
-import no.risc.risc.RiScContentResultDTO
+import no.risc.risc.models.ContentStatus
+import no.risc.risc.models.DecryptionFailureDTO
+import no.risc.risc.models.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessingStatus
+import no.risc.risc.models.RiScContentResultDTO
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -92,9 +92,9 @@ internal class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
     @ExceptionHandler(SOPSDecryptionException::class)
-    fun handleSopsDecryptionException(ex: SOPSDecryptionException): DecryptionFailure {
+    fun handleSopsDecryptionException(ex: SOPSDecryptionException): DecryptionFailureDTO {
         logger.error(ex.message, ex)
-        return DecryptionFailure(
+        return DecryptionFailureDTO(
             status = ContentStatus.DecryptionFailed,
             message = ex.message,
         )

--- a/src/main/kotlin/no/risc/exception/exceptions/AccessTokenValidationFailedException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/AccessTokenValidationFailedException.kt
@@ -1,10 +1,10 @@
 package no.risc.exception.exceptions
 
 import no.risc.infra.connector.models.GitHubPermission
-import no.risc.risc.ContentStatus
-import no.risc.risc.ProcessRiScResultDTO
-import no.risc.risc.ProcessingStatus
-import no.risc.risc.RiScContentResultDTO
+import no.risc.risc.models.ContentStatus
+import no.risc.risc.models.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessingStatus
+import no.risc.risc.models.RiScContentResultDTO
 
 data class AccessTokenValidationFailedException(
     val permissionNeeded: GitHubPermission,

--- a/src/main/kotlin/no/risc/exception/exceptions/FetchException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/FetchException.kt
@@ -1,6 +1,6 @@
 package no.risc.exception.exceptions
 
-import no.risc.risc.ProcessingStatus
+import no.risc.risc.models.ProcessingStatus
 
 data class FetchException(
     override val message: String,

--- a/src/main/kotlin/no/risc/exception/exceptions/GitHubFetchException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/GitHubFetchException.kt
@@ -1,6 +1,6 @@
 package no.risc.exception.exceptions
 
-import no.risc.risc.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessRiScResultDTO
 
 data class GitHubFetchException(
     override val message: String,

--- a/src/main/kotlin/no/risc/exception/exceptions/RepositoryAccessException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/RepositoryAccessException.kt
@@ -1,10 +1,10 @@
 package no.risc.exception.exceptions
 
 import no.risc.infra.connector.models.GitHubPermission
-import no.risc.risc.ContentStatus
-import no.risc.risc.ProcessRiScResultDTO
-import no.risc.risc.ProcessingStatus
-import no.risc.risc.RiScContentResultDTO
+import no.risc.risc.models.ContentStatus
+import no.risc.risc.models.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessingStatus
+import no.risc.risc.models.RiScContentResultDTO
 
 data class RepositoryAccessException(
     val permissionNeeded: GitHubPermission,

--- a/src/main/kotlin/no/risc/exception/exceptions/SopsConfigGenerateFetchException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/SopsConfigGenerateFetchException.kt
@@ -1,6 +1,6 @@
 package no.risc.exception.exceptions
 
-import no.risc.risc.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessRiScResultDTO
 import java.lang.Exception
 
 data class SopsConfigGenerateFetchException(

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -20,11 +20,11 @@ import no.risc.infra.connector.WebClientConnector
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.infra.connector.models.GithubAccessToken
 import no.risc.infra.connector.models.RepositoryInfo
-import no.risc.risc.LastPublished
-import no.risc.risc.ProcessRiScResultDTO
-import no.risc.risc.ProcessingStatus
-import no.risc.risc.RiScIdentifier
-import no.risc.risc.RiScStatus
+import no.risc.risc.models.LastPublished
+import no.risc.risc.models.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessingStatus
+import no.risc.risc.models.RiScIdentifier
+import no.risc.risc.models.RiScStatus
 import no.risc.risc.models.UserInfo
 import no.risc.utils.decodeBase64
 import no.risc.utils.encodeBase64

--- a/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/google/GoogleServiceIntegration.kt
@@ -17,7 +17,7 @@ import no.risc.infra.connector.GcpCloudResourceApiConnector
 import no.risc.infra.connector.GcpKmsApiConnector
 import no.risc.infra.connector.GoogleOAuthApiConnector
 import no.risc.infra.connector.models.GCPAccessToken
-import no.risc.risc.ProcessingStatus
+import no.risc.risc.models.ProcessingStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -3,8 +3,8 @@ package no.risc.initRiSc
 import no.risc.exception.exceptions.SopsConfigGenerateFetchException
 import no.risc.infra.connector.InitRiScServiceConnector
 import no.risc.initRiSc.model.GenerateRiScRequestBody
-import no.risc.risc.ProcessRiScResultDTO
-import no.risc.risc.ProcessingStatus
+import no.risc.risc.models.ProcessRiScResultDTO
+import no.risc.risc.models.ProcessingStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.awaitBodyOrNull

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -5,8 +5,11 @@ import no.risc.github.GithubConnector
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.infra.connector.models.GithubAccessToken
+import no.risc.risc.models.CreateRiScResultDTO
 import no.risc.risc.models.DifferenceDTO
 import no.risc.risc.models.DifferenceRequestBody
+import no.risc.risc.models.PublishRiScResultDTO
+import no.risc.risc.models.RiScContentResultDTO
 import no.risc.risc.models.RiScWrapperObject
 import no.risc.risc.models.UserInfo
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -1,8 +1,13 @@
 package no.risc.risc.models
 
-import no.risc.risc.DifferenceStatus
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import no.risc.utils.Difference
+import no.risc.utils.KOffsetDateTimeSerializer
+import java.time.OffsetDateTime
 
+@Serializable
 data class DifferenceDTO(
     val status: DifferenceStatus,
     val differenceState: Difference,
@@ -10,6 +15,155 @@ data class DifferenceDTO(
     val defaultLastModifiedDateString: String = "",
 )
 
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonIgnoreUnknownKeys
 data class DifferenceRequestBody(
     val riSc: String,
 )
+
+@Serializable
+data class DecryptionFailureDTO(
+    val status: ContentStatus,
+    val message: String,
+)
+
+@Serializable
+data class CreateRiScResultDTO(
+    val riScId: String,
+    val status: ProcessingStatus,
+    val statusMessage: String,
+    val riScContent: String?,
+    val sopsConfig: SopsConfig,
+)
+
+@Serializable
+data class LastPublished(
+    @Serializable(KOffsetDateTimeSerializer::class)
+    val dateTime: OffsetDateTime,
+    val numberOfCommits: Int,
+)
+
+@Serializable
+data class RiScContentResultDTO(
+    val riScId: String,
+    val status: ContentStatus,
+    val riScStatus: RiScStatus?,
+    val riScContent: String?,
+    val lastPublished: LastPublished? = null,
+    val sopsConfig: SopsConfig? = null,
+    val pullRequestUrl: String? = null,
+    val migrationStatus: MigrationStatus =
+        MigrationStatus(
+            migrationChanges = false,
+            migrationRequiresNewApproval = false,
+            migrationVersions =
+                MigrationVersions(
+                    fromVersion = null,
+                    toVersion = null,
+                ),
+        ),
+)
+
+@Serializable
+data class MigrationStatus(
+    val migrationChanges: Boolean,
+    val migrationRequiresNewApproval: Boolean,
+    val migrationVersions: MigrationVersions,
+)
+
+@Serializable
+data class MigrationVersions(
+    var fromVersion: String?,
+    var toVersion: String?,
+)
+
+enum class ContentStatus {
+    Success,
+    FileNotFound,
+    DecryptionFailed,
+    Failure,
+    NoReadAccess,
+    SchemaNotFound,
+    SchemaValidationFailed,
+}
+
+enum class DifferenceStatus {
+    Success,
+    GithubFailure,
+    GithubFileNotFound,
+    JsonFailure,
+    DecryptionFailure,
+    NoReadAccess,
+    SchemaNotFound,
+    SchemaValidationFailed,
+}
+
+@Serializable
+abstract class RiScResult {
+    abstract val riScId: String
+    abstract val status: ProcessingStatus
+    abstract val statusMessage: String
+}
+
+class ProcessRiScResultDTO(
+    override val riScId: String,
+    override val status: ProcessingStatus,
+    override val statusMessage: String,
+) : RiScResult() {
+    companion object {
+        val INVALID_ACCESS_TOKENS =
+            ProcessRiScResultDTO(
+                "",
+                ProcessingStatus.InvalidAccessTokens,
+                "Invalid risk scorecard result: ${ProcessingStatus.InvalidAccessTokens.message}",
+            )
+    }
+}
+
+@Serializable
+class PublishRiScResultDTO(
+    override val riScId: String,
+    override val status: ProcessingStatus,
+    override val statusMessage: String,
+    val pendingApproval: PendingApprovalDTO?,
+) : RiScResult()
+
+@Serializable
+data class PendingApprovalDTO(
+    val pullRequestUrl: String,
+    val pullRequestName: String,
+)
+
+enum class ProcessingStatus(
+    val message: String,
+) {
+    ErrorWhenUpdatingRiSc("Error when updating risk scorecard"),
+    CreatedRiSc("Created new risk scorecard successfully"),
+    UpdatedRiSc("Updated risk scorecard successfully"),
+    UpdatedRiScAndCreatedPullRequest("Updated risk scorecard and created pull request"),
+    CreatedPullRequest("Created pull request for risk scorecard"),
+    ErrorWhenCreatingPullRequest("Error when creating pull request"),
+    InvalidAccessTokens("Invalid access tokens"),
+    NoWriteAccessToRepository("Permission denied: You do not have write access to repository"),
+    UpdatedRiScRequiresNewApproval("Updated risk scorecard and requires new approval"),
+    ErrorWhenCreatingRiSc("Error when creating risk scorecard"),
+    AccessTokensValidationFailure("Failure when validating access tokens"),
+    FailedToFetchGcpProjectIds("Failed to fetch GCP project IDs"),
+    FailedToFetchGCPOAuth2TokenInformation("Failed to fetch GCP OAuth2 token information"),
+    FailedToFetchGCPIAMPermissions("Failed to fetch GCP IAM permissions for crypto key"),
+    FailedToCreateSops("Failed to create SOPS configuration"),
+}
+
+@Serializable
+data class RiScIdentifier(
+    val id: String,
+    var status: RiScStatus,
+    val pullRequestUrl: String? = null,
+)
+
+enum class RiScStatus {
+    Draft,
+    SentForApproval,
+    Published,
+}

--- a/src/main/kotlin/no/risc/risc/models/InternDifference.kt
+++ b/src/main/kotlin/no/risc/risc/models/InternDifference.kt
@@ -1,0 +1,17 @@
+package no.risc.risc.models
+
+import no.risc.utils.Difference
+
+class InternDifference(
+    val status: DifferenceStatus,
+    val differenceState: Difference,
+    val errorMessage: String = "",
+) {
+    fun toDTO(date: String = ""): DifferenceDTO =
+        DifferenceDTO(
+            status = status,
+            differenceState = differenceState,
+            errorMessage = errorMessage,
+            defaultLastModifiedDateString = date,
+        )
+}

--- a/src/main/kotlin/no/risc/risc/models/RiScWrapperObject.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiScWrapperObject.kt
@@ -1,5 +1,8 @@
 package no.risc.risc.models
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class RiScWrapperObject(
     val riSc: String,
     val isRequiresNewApproval: Boolean,

--- a/src/main/kotlin/no/risc/risc/models/SopsConfig.kt
+++ b/src/main/kotlin/no/risc/risc/models/SopsConfig.kt
@@ -1,7 +1,7 @@
 package no.risc.risc.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonIgnoreUnknownKeys
@@ -11,22 +11,22 @@ import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 @OptIn(ExperimentalSerializationApi::class)
 @JsonIgnoreUnknownKeys
 data class SopsConfig(
-    @JsonProperty("shamir_threshold") val shamir_threshold: Int,
-    @JsonProperty("key_groups") val key_groups: List<KeyGroup>?,
-    @JsonProperty("kms") val kms: List<JsonElement>? = null,
-    @JsonProperty("gcp_kms") val gcp_kms: List<GcpKmsEntry>,
-    @JsonProperty("age") val age: List<AgeEntry>? = null,
-    @JsonProperty("lastmodified") val lastModified: String? = null,
-    @JsonProperty("mac") val mac: String? = null,
-    @JsonProperty("unencrypted_suffix") val unencryptedSuffix: String? = null,
-    @JsonProperty("version") val version: String? = null,
+    @SerialName("shamir_threshold") val shamirThreshold: Int,
+    @SerialName("key_groups") val keyGroups: List<KeyGroup>? = emptyList(),
+    val kms: List<JsonElement>? = null,
+    @SerialName("gcp_kms") val gcpKms: List<GcpKmsEntry>,
+    val age: List<AgeEntry>? = null,
+    @SerialName("lastmodified") val lastModified: String? = null,
+    val mac: String? = null,
+    @SerialName("unencrypted_suffix") val unencryptedSuffix: String? = null,
+    val version: String? = null,
 )
 
 @Serializable
 data class GcpKmsEntry(
-    @JsonProperty("resource_id") val resource_id: String,
-    @JsonProperty("created_at") val created_at: String? = null,
-    @JsonProperty("enc") val enc: String? = null,
+    @SerialName("resource_id") val resourceId: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    val enc: String? = null,
 )
 
 @Serializable
@@ -37,7 +37,7 @@ data class AgeEntry(
 
 @Serializable
 data class KeyGroup(
-    @JsonProperty("gcp_kms") val gcp_kms: List<GcpKmsEntry>? = null,
-    @JsonProperty("hc_vault") val hc_vault: List<JsonElement>? = null,
-    @JsonProperty("age") val age: List<AgeEntry>? = null,
+    @SerialName("gcp_kms") val gcpKms: List<GcpKmsEntry>? = null,
+    @SerialName("hc_vault") val hcVault: List<JsonElement>? = null,
+    val age: List<AgeEntry>? = null,
 )

--- a/src/main/kotlin/no/risc/risc/models/UserInfo.kt
+++ b/src/main/kotlin/no/risc/risc/models/UserInfo.kt
@@ -1,8 +1,12 @@
 package no.risc.risc.models
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonIgnoreUnknownKeys
 data class UserInfo(
     val name: String,
     val email: String,

--- a/src/main/kotlin/no/risc/security/ValidationService.kt
+++ b/src/main/kotlin/no/risc/security/ValidationService.kt
@@ -6,7 +6,7 @@ import no.risc.exception.exceptions.RepositoryAccessException
 import no.risc.github.GithubConnector
 import no.risc.google.GoogleServiceIntegration
 import no.risc.infra.connector.models.GitHubPermission
-import no.risc.risc.ProcessingStatus
+import no.risc.risc.models.ProcessingStatus
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import no.risc.risc.MigrationStatus
-import no.risc.risc.RiScContentResultDTO
+import no.risc.risc.models.MigrationStatus
+import no.risc.risc.models.RiScContentResultDTO
 
 /**
  * Migrates the supplied RiSc from its current version to supplied latest supported version if possible. Migration is

--- a/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/encryption/CryptoServiceIntegrationTests.kt
@@ -43,9 +43,9 @@ class CryptoServiceIntegrationTests {
                     text = "test",
                     sopsConfig =
                         SopsConfig(
-                            shamir_threshold = 2,
-                            key_groups = null,
-                            gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                            shamirThreshold = 2,
+                            keyGroups = null,
+                            gcpKms = listOf(GcpKmsEntry(resourceId = "test")),
                         ),
                     gcpAccessToken = GCPAccessToken("testToken"),
                     riScId = "riScId",
@@ -67,9 +67,9 @@ class CryptoServiceIntegrationTests {
                     text = "test",
                     sopsConfig =
                         SopsConfig(
-                            shamir_threshold = 2,
-                            key_groups = null,
-                            gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                            shamirThreshold = 2,
+                            keyGroups = null,
+                            gcpKms = listOf(GcpKmsEntry(resourceId = "test")),
                         ),
                     gcpAccessToken = GCPAccessToken("testToken"),
                     riScId = "riScId",
@@ -85,9 +85,9 @@ class CryptoServiceIntegrationTests {
                 riSc = "test",
                 sopsConfig =
                     SopsConfig(
-                        shamir_threshold = 2,
-                        key_groups = null,
-                        gcp_kms = listOf(GcpKmsEntry(resource_id = "test")),
+                        shamirThreshold = 2,
+                        keyGroups = null,
+                        gcpKms = listOf(GcpKmsEntry(resourceId = "test")),
                     ),
             )
 

--- a/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
+++ b/src/test/kotlin/no/risc/github/GithubConnectorTests.kt
@@ -23,9 +23,9 @@ import no.risc.github.models.GithubStatus
 import no.risc.github.models.GithubWriteToFilePayload
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.infra.connector.models.GithubAccessToken
-import no.risc.risc.LastPublished
-import no.risc.risc.RiScIdentifier
-import no.risc.risc.RiScStatus
+import no.risc.risc.models.LastPublished
+import no.risc.risc.models.RiScIdentifier
+import no.risc.risc.models.RiScStatus
 import no.risc.risc.models.UserInfo
 import no.risc.utils.encodeBase64
 import no.risc.utils.generateRandomAlphanumericString

--- a/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import no.risc.risc.ContentStatus
-import no.risc.risc.MigrationStatus
-import no.risc.risc.MigrationVersions
-import no.risc.risc.RiScContentResultDTO
-import no.risc.risc.RiScStatus
+import no.risc.risc.models.ContentStatus
+import no.risc.risc.models.MigrationStatus
+import no.risc.risc.models.MigrationVersions
+import no.risc.risc.models.RiScContentResultDTO
+import no.risc.risc.models.RiScStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
Removes the remaining usage of FasterXML Jackson in the project:

- Use `kotlinx-serialization` for RiSc and crypto DTOs.
- Moves the DTOs to the associated `model` directory.
- Removes the direct dependency to FasterXML Jackson.