### PR TITLE
Remove tomcat-embed-core version pin. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,11 +43,6 @@ val junitVersion = "5.12.2"
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    implementation("org.apache.tomcat.embed:tomcat-embed-core") {
-        version {
-            strictly("11.0.5")
-        }
-    }
     implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-security:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")


### PR DESCRIPTION
Removes the pin of the `tomcat-embed-core` version. This library is not a direct dependency of the project, but rather a transitive dependency through `spring-boot-starter`. The version was pined earlier (in #311) to upgrade away from a vulnerable version. This pin is no longer needed, as the version used by `spring-boot-starter` is no longer vulnerable.

This solves multiple security alerts in the project, as the current pined version of `tomcat-embed-core` has recently discovered vulnerabilities.