### PR TITLE
Upgrade Ktlint to version 1.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 ktlint {
-    version.set("1.5.0")
+    version.set("1.6.0")
 }
 
 group = "no"


### PR DESCRIPTION
Upgrades Ktlint to version 1.6.0 (the newest version). Fixes two open security alerts [39](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/dependabot/39) and [40](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/dependabot/40).