### PR TITLE
Make sure that all difference types are always included on serialisation

### DIFF
--- a/src/main/kotlin/no/risc/utils/DifferenceComparer.kt
+++ b/src/main/kotlin/no/risc/utils/DifferenceComparer.kt
@@ -1,16 +1,19 @@
 package no.risc.utils
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class Difference(
-    val entriesOnLeft: List<String> = listOf(),
-    val entriesOnRight: List<String> = listOf(),
-    val difference: List<String> = listOf(),
+    @EncodeDefault val entriesOnLeft: List<String> = listOf(),
+    @EncodeDefault val entriesOnRight: List<String> = listOf(),
+    @EncodeDefault val difference: List<String> = listOf(),
 )
 
 /**


### PR DESCRIPTION
Currently, serialisation does not include fields if their value is set to the default value. This is the expected behaviour, as default values are mostly used on nullable fields. However, in the case of `Difference`–the DTO for differences between the published RiSc and the current draft of the same RiSc–it would make sense to include all types of differences, even if there are no changes of a specific type. This PR makes sure that we serialise all types of differences.

This fixes a bug in the frontend, where missing difference types will cause a crash. An issue that will show up when accepting changes for the migration from version 4.0 to 4.1.