### PR TITLE
Add change tracking for migrations from 3.3 to 4.0 and 4.0 to 4.1.

### DIFF
--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import no.risc.utils.Difference
 import no.risc.utils.KOffsetDateTimeSerializer
+import no.risc.utils.comparison.MigrationChange40
+import no.risc.utils.comparison.MigrationChange41
 import java.time.OffsetDateTime
 
 @Serializable
@@ -70,6 +72,8 @@ data class MigrationStatus(
     val migrationChanges: Boolean,
     val migrationRequiresNewApproval: Boolean,
     val migrationVersions: MigrationVersions,
+    val migrationChanges40: MigrationChange40? = null,
+    val migrationChanges41: MigrationChange41? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
@@ -1,0 +1,62 @@
+package no.risc.utils.comparison
+
+import kotlinx.serialization.Serializable
+
+data class MigrationChanges(
+    val migrationChange40: MigrationChange40? = null,
+    val migrationChange41: MigrationChange41? = null,
+)
+
+// Changes for the migration from version 3.3 to 4.0
+
+@Serializable
+data class MigrationChange40(
+    val scenarios: List<MigrationChange40Scenario>,
+)
+
+@Serializable
+data class MigrationChange40Scenario(
+    val title: String,
+    val id: String,
+    val removedExistingActions: String? = null,
+    val changedVulnerabilities: List<MigrationChangedValue<String>>,
+    val changedActions: List<MigrationChange40Action>,
+)
+
+@Serializable
+data class MigrationChange40Action(
+    val title: String,
+    val id: String,
+    val removedOwner: String? = null,
+    val removedDeadline: String? = null,
+)
+
+// Changes for the migration from version 4.0 to 4.1
+
+@Serializable
+data class MigrationChange41(
+    val scenarios: List<MigrationChange41Scenario>,
+)
+
+@Serializable
+data class MigrationChange41Scenario(
+    val title: String,
+    val id: String,
+    var changedRiskProbability: MigrationChangedValue<Double>? = null,
+    var changedRiskConsequence: MigrationChangedValue<Int>? = null,
+    var changedRemainingRiskProbability: MigrationChangedValue<Double>? = null,
+    var changedRemainingRiskConsequence: MigrationChangedValue<Int>? = null,
+) {
+    fun hasChanges() =
+        changedRiskConsequence !== null ||
+            changedRiskProbability !== null ||
+            changedRemainingRiskConsequence != null ||
+            changedRemainingRiskProbability != null
+}
+
+// General change object
+@Serializable
+data class MigrationChangedValue<T>(
+    val oldValue: T,
+    val newValue: T,
+)

--- a/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
@@ -10,9 +10,18 @@ import no.risc.risc.models.MigrationStatus
 import no.risc.risc.models.MigrationVersions
 import no.risc.risc.models.RiScContentResultDTO
 import no.risc.risc.models.RiScStatus
+import no.risc.utils.comparison.MigrationChange40
+import no.risc.utils.comparison.MigrationChange40Action
+import no.risc.utils.comparison.MigrationChange40Scenario
+import no.risc.utils.comparison.MigrationChange41
+import no.risc.utils.comparison.MigrationChange41Scenario
+import no.risc.utils.comparison.MigrationChangedValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
 import java.io.File
 
 class MigrationFunctionTests {
@@ -75,25 +84,30 @@ class MigrationFunctionTests {
         val schemaVersion = migratedJsonObject["schemaVersion"]?.jsonPrimitive?.content
         assertEquals("4.0", schemaVersion)
 
-        // Check that existingActions has been removed
         val scenarios = migratedJsonObject["scenarios"]?.jsonArray
-        scenarios?.forEach { scenario ->
+        scenarios?.forEachIndexed { index, scenario ->
             val scenarioObject = scenario.jsonObject
             val scenarioDetails = scenarioObject["scenario"]?.jsonObject
 
             scenarioDetails?.let {
+                // Check that existingActions has been removed
                 assertFalse(it.containsKey("existingActions"))
 
                 val vulnerabilitiesArray =
                     it["vulnerabilities"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
 
                 val expectedVulnerabilities =
-                    listOf(
-                        "Unmonitored use",
-                        "Unauthorized access",
-                        "Information leak",
-                        "Excessive use",
-                    )
+                    if (index == 0) {
+                        listOf(
+                            "Unmonitored use",
+                            "Unauthorized access",
+                            "Information leak",
+                            "Excessive use",
+                            "Misconfiguration",
+                        )
+                    } else {
+                        listOf("Misconfiguration")
+                    }
                 assertEquals(expectedVulnerabilities, vulnerabilitiesArray)
 
                 val actionsArray = it["actions"]?.jsonArray
@@ -106,9 +120,74 @@ class MigrationFunctionTests {
                 }
             }
 
-            assertEquals(true, migratedObject.migrationStatus?.migrationChanges)
-            assertEquals(true, migratedObject.migrationStatus?.migrationRequiresNewApproval)
+            assertEquals(true, migratedObject.migrationStatus.migrationChanges)
+            assertEquals(true, migratedObject.migrationStatus.migrationRequiresNewApproval)
         }
+
+        assertNotNull(
+            migratedObject.migrationStatus.migrationChanges40,
+            "When changes have been made, there should be a migration changes object.",
+        )
+
+        val changedScenarios = migratedObject.migrationStatus.migrationChanges40.scenarios
+
+        assertEquals(1, changedScenarios.size, "Only changed scenarios should be included in the migration changes.")
+
+        val changedScenario = changedScenarios[0]
+
+        assertEquals("14Kap", changedScenario.id, "The scenario with ID 14Kap should have changes made.")
+        assertEquals(
+            "Ondsinnet bruker ønsker å ta ned løsningen. ",
+            changedScenario.title,
+            "The scenario title should be included with the changes.",
+        )
+
+        // Removed existing actions
+        assertEquals(
+            "Ddos protection. ",
+            changedScenario.removedExistingActions,
+            "The removedExistingActions field should be equal to the removed string.",
+        )
+
+        // Changed actions
+        assertEquals(
+            1,
+            changedScenario.changedActions.size,
+            "Only changed actions should be included in the migration changes.",
+        )
+        val expectedChangedAction =
+            MigrationChange40Action(
+                title = "Innlogging",
+                id = "w100Q",
+                removedOwner = "Kåre",
+                removedDeadline = "2024-06-12",
+            )
+        assertEquals(
+            expectedChangedAction,
+            changedScenario.changedActions[0],
+            "The removed owner and deadline fields should be equal to the removed strings.",
+        )
+
+        // Changed vulnerabilities
+        assertEquals(
+            5,
+            changedScenario.changedVulnerabilities.size,
+            "Only changed vulnerabilities should be included in the migration changes.",
+        )
+
+        val expectedChanges =
+            listOf(
+                MigrationChangedValue("User repudiation", "Unmonitored use"),
+                MigrationChangedValue("Compromised admin user", "Unauthorized access"),
+                MigrationChangedValue("Escalation of rights", "Unauthorized access"),
+                MigrationChangedValue("Disclosed secret", "Information leak"),
+                MigrationChangedValue("Denial of service", "Excessive use"),
+            )
+
+        assertTrue(
+            { changedScenario.changedVulnerabilities.containsAll(expectedChanges) },
+            "All changes, even those going to the same new vulnerability value should be included in the changes.",
+        )
     }
 
     @Test
@@ -137,6 +216,11 @@ class MigrationFunctionTests {
 
         val schemaVersion = migratedJsonObject["schemaVersion"]?.jsonPrimitive?.content
         assertEquals("4.0", schemaVersion)
+
+        assertNull(
+            migratedObject.migrationStatus.migrationChanges40,
+            "When no changes have been made, there should be no migration changes object.",
+        )
     }
 
     @Test
@@ -197,18 +281,72 @@ class MigrationFunctionTests {
             testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 8_000, 0.0025)
         }
         scenariosJsonObjects?.get(1)?.let {
-            testConsequenceAndProbability(it["risk"]?.jsonObject, 64_000_000, 20)
-            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 3_200_000, 1)
+            testConsequenceAndProbability(it["risk"]?.jsonObject, 64_000_000, 20.0)
+            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 3_200_000, 1.0)
         }
         scenariosJsonObjects?.get(2)?.let {
-            testConsequenceAndProbability(it["risk"]?.jsonObject, 1_280_000_000, 400)
+            testConsequenceAndProbability(it["risk"]?.jsonObject, 1_280_000_000, 400.0)
 
             // Specific values not equal to the preset values should not be changed
             testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 198_000, 0.123)
         }
 
-        assertEquals(true, migratedObject.migrationStatus?.migrationChanges)
-        assertEquals(true, migratedObject.migrationStatus?.migrationRequiresNewApproval)
+        assertEquals(true, migratedObject.migrationStatus.migrationChanges)
+        assertEquals(true, migratedObject.migrationStatus.migrationRequiresNewApproval)
+
+        assertNotNull(
+            migratedObject.migrationStatus.migrationChanges41,
+            "When changes have been made, there should be a migration changes object.",
+        )
+
+        val changedScenarios = migratedObject.migrationStatus.migrationChanges41.scenarios
+
+        assertEquals(3, changedScenarios.size, "All changed scenarios should be included in the migration changes.")
+
+        val expectedFirstScenarioChanges =
+            MigrationChange41Scenario(
+                title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
+                id = "14Kap",
+                changedRiskProbability = MigrationChangedValue(0.1, 0.05),
+                changedRiskConsequence = MigrationChangedValue(30_000, 160_000),
+                changedRemainingRiskProbability = MigrationChangedValue(0.01, 0.0025),
+                changedRemainingRiskConsequence = MigrationChangedValue(1_000, 8_000),
+            )
+
+        assertEquals(
+            expectedFirstScenarioChanges,
+            changedScenarios[0],
+            "The changed values of the first scenario should be properly included.",
+        )
+
+        val expectedSecondScenarioChanges =
+            MigrationChange41Scenario(
+                title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
+                id = "25FcD",
+                changedRiskProbability = MigrationChangedValue(50.0, 20.0),
+                changedRiskConsequence = MigrationChangedValue(30_000_000, 64_000_000),
+                changedRemainingRiskConsequence = MigrationChangedValue(1_000_000, 3_200_000),
+            )
+
+        assertEquals(
+            expectedSecondScenarioChanges,
+            changedScenarios[1],
+            "The changed values of the second scenario should be properly included, but unchanged values should not.",
+        )
+
+        val expectedThirdScenarioChanges =
+            MigrationChange41Scenario(
+                title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
+                id = "2dsFd",
+                changedRiskProbability = MigrationChangedValue(300.0, 400.0),
+                changedRiskConsequence = MigrationChangedValue(1_000_000_000, 1_280_000_000),
+            )
+
+        assertEquals(
+            expectedThirdScenarioChanges,
+            changedScenarios[2],
+            "The changed values of the third scenario should be properly included, but unchanged values should not.",
+        )
     }
 
     @Test
@@ -238,5 +376,54 @@ class MigrationFunctionTests {
 
         val schemaVersion = migratedJsonObject["schemaVersion"]?.jsonPrimitive?.content
         assertEquals(latestSupportedVersion, schemaVersion)
+
+        val expected40MigrationChanges =
+            MigrationChange40(
+                scenarios =
+                    listOf(
+                        MigrationChange40Scenario(
+                            title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
+                            id = "14Kap",
+                            removedExistingActions = "Ddos protection. ",
+                            changedVulnerabilities =
+                                listOf(
+                                    MigrationChangedValue("Denial of service", "Excessive use"),
+                                ),
+                            changedActions =
+                                listOf(
+                                    MigrationChange40Action(
+                                        title = "Innlogging",
+                                        id = "w100Q",
+                                        removedOwner = "Kåre",
+                                        removedDeadline = "2024-06-12",
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+        assertEquals(
+            expected40MigrationChanges,
+            migratedObject.migrationStatus.migrationChanges40,
+            "Changes made from version 3.3 to 4.0 should be included.",
+        )
+
+        val expected41MigrationChanges =
+            MigrationChange41(
+                scenarios =
+                    listOf(
+                        MigrationChange41Scenario(
+                            title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
+                            id = "14Kap",
+                            changedRiskConsequence = MigrationChangedValue(1_000, 8_000),
+                            changedRemainingRiskConsequence = MigrationChangedValue(1_000, 8_000),
+                            changedRemainingRiskProbability = MigrationChangedValue(0.1, 0.05),
+                        ),
+                    ),
+            )
+        assertEquals(
+            expected41MigrationChanges,
+            migratedObject.migrationStatus.migrationChanges41,
+            "Changes made from version 4.0 to 4.1 should be included.",
+        )
     }
 }

--- a/src/test/resources/3.2.json
+++ b/src/test/resources/3.2.json
@@ -24,7 +24,7 @@
         "existingActions": "Ddos protection. ",
         "actions": [
           {
-            "title": "",
+            "title": "Innlogging",
             "action": {
               "ID": "w100Q",
               "description": "Innlogging. ",

--- a/src/test/resources/3.3.json
+++ b/src/test/resources/3.3.json
@@ -17,7 +17,8 @@
           "Compromised admin user",
           "Escalation of rights",
           "Disclosed secret",
-          "Denial of service"
+          "Denial of service",
+          "Misconfiguration"
         ],
         "risk": {
           "summary": "",
@@ -27,12 +28,20 @@
         "existingActions": "Ddos protection. ",
         "actions": [
           {
-            "title": "",
+            "title": "Innlogging",
             "action": {
               "ID": "w100Q",
               "description": "Innlogging. ",
               "owner": "Kåre",
               "deadline": "2024-06-12",
+              "status": "Not started"
+            }
+          },
+          {
+            "title": "",
+            "action": {
+              "ID": "z4B01",
+              "description": "Innlogging. ",
               "status": "Not started"
             }
           }
@@ -41,6 +50,39 @@
           "summary": "",
           "probability": 0.1,
           "consequence": 1000
+        }
+      }
+    },
+    {
+      "title": "Tilgang til administratorbruker havner i feil hender.",
+      "scenario": {
+        "ID": "2dsFd",
+        "description": "Tilgang til administratorbruker havner i feil hender og persondata havner på avveie.",
+        "threatActors": [
+          "Organised crime"
+        ],
+        "vulnerabilities": [
+          "Misconfiguration"
+        ],
+        "risk": {
+          "summary": "",
+          "probability": 300,
+          "consequence": 1000000000
+        },
+        "actions": [
+          {
+            "title": "",
+            "action": {
+              "ID": "w100Q",
+              "description": "Innlogging. ",
+              "status": "Not started"
+            }
+          }
+        ],
+        "remainingRisk": {
+          "summary": "",
+          "probability": 0.123,
+          "consequence": 198000
         }
       }
     }


### PR DESCRIPTION
Adds change tracking for migrations. Specifically, the following change tracking is added:
- **Version 3.3 to version 4.0:** For each scenario, removal of `existingActions` if there was any content and changed vulnerabilities (if any). For each action, removed `owner` and `deadline` fields, if they had any content originally.
- **Version 4.0 to version 4.1:** For each scenario, actual changes to probability and consequence for `risk` and `remainingRisk`.

The tracked changes are included in the migration data sent from the backend to the endpoint caller.

This PR is part of a bigger project to improve how differences in RiScs are displayed.