### PR TITLE
Increases the memory available to CodeQL to fix GitHub workflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Define RAM limit of 4GB to avoid CodeQL workflow OOM errors
+kotlin.daemon.jvmargs=-Xmx4096M


### PR DESCRIPTION
Increases the memory available to CodeQL to 4GB to fix the GitHub workflow that fails with an OOM exception. This is the recommended fix from CodeQL.