### PR TITLE
Model RiSc in backend

### DIFF
--- a/docs/schemaChangelog.md
+++ b/docs/schemaChangelog.md
@@ -32,6 +32,7 @@
   - Escalation of rights -> Unauthorized access
   - Disclosed secret -> Information leak
   - Denial of service -> Excessive use
+  - Introduced "Flawed design"
 
 ## 3.3
 - Adds url field in actions

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -152,7 +152,7 @@ data class RiScScenarioRisk(
 object RiScScenarioActionSerializer : FlattenSerializer<RiScScenarioAction>(
     serializer = RiScScenarioAction.generatedSerializer(),
     flattenKey = "action",
-    subKeys = listOf("ID", "url", "status"),
+    subKeys = listOf("ID", "url", "status", "description"),
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -162,6 +162,7 @@ data class RiScScenarioAction(
     val title: String,
     @SerialName("ID")
     val id: String,
+    val description: String,
     val url: String? = null,
     val status: RiScScenarioActionStatus,
 )

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -2,19 +2,194 @@ package no.risc.risc.models
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KeepGeneratedSerializer
+import kotlinx.serialization.SealedSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.risc.utils.FlattenSerializer
 
-// Models the RiSc schema for version 4.*
+/***************
+ * VERSION 4.X *
+ ***************/
 @Serializable
-data class RiSc(
+data class RiSc4X(
     val schemaVersion: String,
     val title: String,
     val scope: String,
     val valuations: List<RiScValuation>?,
-    val scenarios: List<RiScScenario>,
+    val scenarios: List<RiSc4XScenario>,
 )
+
+object RiSc4XScenarioSerializer : FlattenSerializer<RiSc4XScenario>(
+    serializer = RiSc4XScenario.generatedSerializer(),
+    flattenKey = "scenario",
+    subKeys = listOf("ID", "description", "url", "threatActors", "vulnerabilities", "risk", "remainingRisk", "actions"),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiSc4XScenarioSerializer::class)
+data class RiSc4XScenario(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val description: String,
+    val url: String? = null,
+    val threatActors: List<RiScScenarioThreatActor>,
+    val vulnerabilities: List<RiSc4XScenarioVulnerability>,
+    val risk: RiScScenarioRisk,
+    val remainingRisk: RiScScenarioRisk,
+    val actions: List<RiSc4XScenarioAction>,
+)
+
+@Serializable
+enum class RiSc4XScenarioVulnerability {
+    @SerialName("Flawed design")
+    FLAWED_DESIGN,
+
+    @SerialName("Misconfiguration")
+    MISCONFIGURATION,
+
+    @SerialName("Dependency vulnerability")
+    DEPENDENCY_VULNERABILITY,
+
+    @SerialName("Unauthorized access")
+    UNAUTHORIZED_ACCESS,
+
+    @SerialName("Unmonitored use")
+    UNMONITORED_USE,
+
+    @SerialName("Input tampering")
+    INPUT_TAMPERING,
+
+    @SerialName("Information leak")
+    INFORMATION_LEAK,
+
+    @SerialName("Excessive use")
+    EXCESSIVE_USE, ;
+
+    override fun toString(): String = serializer().descriptor.getElementName(ordinal)
+}
+
+object RiSc4XScenarioActionSerializer : FlattenSerializer<RiSc4XScenarioAction>(
+    serializer = RiSc4XScenarioAction.generatedSerializer(),
+    flattenKey = "action",
+    subKeys = listOf("ID", "url", "status", "description"),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiSc4XScenarioActionSerializer::class)
+data class RiSc4XScenarioAction(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val description: String,
+    val url: String? = null,
+    val status: RiScScenarioActionStatus,
+)
+
+/***************
+ * VERSION 3.3 *
+ ***************/
+@Serializable
+data class RiSc33(
+    val schemaVersion: String,
+    val title: String,
+    val scope: String,
+    val valuations: List<RiScValuation>?,
+    val scenarios: List<RiSc33Scenario>,
+)
+
+object RiSc33ScenarioSerializer : FlattenSerializer<RiSc33Scenario>(
+    serializer = RiSc33Scenario.generatedSerializer(),
+    flattenKey = "scenario",
+    subKeys =
+        listOf(
+            "ID",
+            "description",
+            "url",
+            "threatActors",
+            "vulnerabilities",
+            "risk",
+            "remainingRisk",
+            "actions",
+            "existingActions",
+        ),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiSc33ScenarioSerializer::class)
+data class RiSc33Scenario(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val description: String,
+    val url: String? = null,
+    val threatActors: List<RiScScenarioThreatActor>,
+    val vulnerabilities: List<RiSc33ScenarioVulnerability>,
+    val risk: RiScScenarioRisk,
+    val remainingRisk: RiScScenarioRisk,
+    val actions: List<RiSc33ScenarioAction>,
+    val existingActions: String? = null,
+)
+
+@OptIn(SealedSerializationApi::class)
+@Serializable
+enum class RiSc33ScenarioVulnerability {
+    @SerialName("Compromised admin user")
+    COMPROMISED_ADMIN_USER,
+
+    @SerialName("Dependency vulnerability")
+    DEPENDENCY_VULNERABILITY,
+
+    @SerialName("Disclosed secret")
+    DISCLOSED_SECRET,
+
+    @SerialName("Misconfiguration")
+    MISCONFIGURATION,
+
+    @SerialName("Input tampering")
+    INPUT_TAMPERING,
+
+    @SerialName("User repudiation")
+    USER_REPUDIATION,
+
+    @SerialName("Information leak")
+    INFORMATION_LEAK,
+
+    @SerialName("Denial of service")
+    DENIAL_OF_SERVICE,
+
+    @SerialName("Escalation of rights")
+    ESCALATION_OF_RIGHTS, ;
+
+    override fun toString(): String = serializer().descriptor.getElementName(ordinal)
+}
+
+object RiSc33ScenarioActionSerializer : FlattenSerializer<RiSc33ScenarioAction>(
+    serializer = RiSc33ScenarioAction.generatedSerializer(),
+    flattenKey = "action",
+    subKeys = listOf("ID", "url", "status", "description", "owner", "deadline"),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiSc33ScenarioActionSerializer::class)
+data class RiSc33ScenarioAction(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val description: String,
+    val url: String? = null,
+    val status: RiScScenarioActionStatus,
+    val deadline: String? = null,
+    val owner: String? = null,
+)
+
+/******************************
+ * SHARED BETWEEN 3.3 AND 4.X *
+ ******************************/
 
 @Serializable
 data class RiScValuation(
@@ -69,28 +244,6 @@ enum class RiScValuationAvailability {
     IMMEDIATE,
 }
 
-object RiScScenarioSerializer : FlattenSerializer<RiScScenario>(
-    serializer = RiScScenario.generatedSerializer(),
-    flattenKey = "scenario",
-    subKeys = listOf("ID", "description", "url", "threatActors", "vulnerabilities", "risk", "remainingRisk", "actions"),
-)
-
-@OptIn(ExperimentalSerializationApi::class)
-@KeepGeneratedSerializer
-@Serializable(with = RiScScenarioSerializer::class)
-data class RiScScenario(
-    val title: String,
-    @SerialName("ID")
-    val id: String,
-    val description: String,
-    val url: String? = null,
-    val threatActors: List<RiScScenarioThreatActor>,
-    val vulnerabilities: List<RiScScenarioVulnerability>,
-    val risk: RiScScenarioRisk,
-    val remainingRisk: RiScScenarioRisk,
-    val actions: List<RiScScenarioAction>,
-)
-
 @Serializable
 enum class RiScScenarioThreatActor {
     @SerialName("Script kiddie")
@@ -116,58 +269,6 @@ enum class RiScScenarioThreatActor {
 }
 
 @Serializable
-enum class RiScScenarioVulnerability {
-    @SerialName("Flawed design")
-    FLAWED_DESIGN,
-
-    @SerialName("Misconfiguration")
-    MISCONFIGURATION,
-
-    @SerialName("Dependency vulnerability")
-    DEPENDENCY_VULNERABILITY,
-
-    @SerialName("Unauthorized access")
-    UNAUTHORIZED_ACCESS,
-
-    @SerialName("Unmonitored use")
-    UNMONITORED_USE,
-
-    @SerialName("Input tampering")
-    INPUT_TAMPERING,
-
-    @SerialName("Information leak")
-    INFORMATION_LEAK,
-
-    @SerialName("Excessive use")
-    EXCESSIVE_USE,
-}
-
-@Serializable
-data class RiScScenarioRisk(
-    val summary: String? = null,
-    val probability: Double,
-    val consequence: Double,
-)
-
-object RiScScenarioActionSerializer : FlattenSerializer<RiScScenarioAction>(
-    serializer = RiScScenarioAction.generatedSerializer(),
-    flattenKey = "action",
-    subKeys = listOf("ID", "url", "status", "description"),
-)
-
-@OptIn(ExperimentalSerializationApi::class)
-@KeepGeneratedSerializer
-@Serializable(with = RiScScenarioActionSerializer::class)
-data class RiScScenarioAction(
-    val title: String,
-    @SerialName("ID")
-    val id: String,
-    val description: String,
-    val url: String? = null,
-    val status: RiScScenarioActionStatus,
-)
-
-@Serializable
 enum class RiScScenarioActionStatus {
     @SerialName("Not started")
     NOT_STARTED,
@@ -184,3 +285,10 @@ enum class RiScScenarioActionStatus {
     @SerialName("Aborted")
     ABORTED,
 }
+
+@Serializable
+data class RiScScenarioRisk(
+    val summary: String? = null,
+    val probability: Double,
+    val consequence: Double,
+)

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -15,7 +15,7 @@ data class RiSc4X(
     val schemaVersion: String,
     val title: String,
     val scope: String,
-    val valuations: List<RiScValuation>?,
+    val valuations: List<RiScValuation>? = null,
     val scenarios: List<RiSc4XScenario>,
 )
 
@@ -70,7 +70,7 @@ enum class RiSc4XScenarioVulnerability {
     override fun toString(): String = serializer().descriptor.getElementName(ordinal)
 }
 
-object RiSc4XScenarioActionSerializer : FlattenSerializer<RiSc4XScenarioAction>(
+private object RiSc4XScenarioActionSerializer : FlattenSerializer<RiSc4XScenarioAction>(
     serializer = RiSc4XScenarioAction.generatedSerializer(),
     flattenKey = "action",
     subKeys = listOf("ID", "url", "status", "description"),
@@ -96,7 +96,7 @@ data class RiSc33(
     val schemaVersion: String,
     val title: String,
     val scope: String,
-    val valuations: List<RiScValuation>?,
+    val valuations: List<RiScValuation>? = null,
     val scenarios: List<RiSc33Scenario>,
 )
 
@@ -167,7 +167,7 @@ enum class RiSc33ScenarioVulnerability {
     override fun toString(): String = serializer().descriptor.getElementName(ordinal)
 }
 
-object RiSc33ScenarioActionSerializer : FlattenSerializer<RiSc33ScenarioAction>(
+private object RiSc33ScenarioActionSerializer : FlattenSerializer<RiSc33ScenarioAction>(
     serializer = RiSc33ScenarioAction.generatedSerializer(),
     flattenKey = "action",
     subKeys = listOf("ID", "url", "status", "description", "owner", "deadline"),

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -1,0 +1,185 @@
+package no.risc.risc.models
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KeepGeneratedSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import no.risc.utils.FlattenSerializer
+
+// Models the RiSc schema for version 4.*
+@Serializable
+data class RiSc(
+    val schemaVersion: String,
+    val title: String,
+    val scope: String,
+    val valuations: List<RiScValuation>?,
+    val scenarios: List<RiScScenario>,
+)
+
+@Serializable
+data class RiScValuation(
+    val description: String,
+    val confidentiality: RiScValuationConfidentiality,
+    val integrity: RiScValuationIntegrity,
+    val availability: RiScValuationAvailability,
+)
+
+@Serializable
+enum class RiScValuationConfidentiality {
+    @SerialName("Public")
+    PUBLIC,
+
+    @SerialName("Internal")
+    INTERNAL,
+
+    @SerialName("Confidential")
+    CONFIDENTIAL,
+
+    @SerialName("Strictly confidential")
+    STRICTLY_CONFIDENTIAL,
+}
+
+@Serializable
+enum class RiScValuationIntegrity {
+    @SerialName("Insignificant")
+    INSIGNIFICANT,
+
+    @SerialName("Expected")
+    EXPECTED,
+
+    @SerialName("Dependent")
+    DEPENDENT,
+
+    @SerialName("Critical")
+    CRITICAL,
+}
+
+@Serializable
+enum class RiScValuationAvailability {
+    @SerialName("Insignificant")
+    INSIGNIFICANT,
+
+    @SerialName("2 days")
+    TWO_DAYS,
+
+    @SerialName("4 hours")
+    FOUR_HOURS,
+
+    @SerialName("Immediate")
+    IMMEDIATE,
+}
+
+object RiScScenarioSerializer : FlattenSerializer<RiScScenario>(
+    serializer = RiScScenario.generatedSerializer(),
+    flattenKey = "scenario",
+    subKeys = listOf("ID", "description", "url", "threatActors", "vulnerabilities", "risk", "remainingRisk", "actions"),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiScScenarioSerializer::class)
+data class RiScScenario(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val description: String,
+    val url: String? = null,
+    val threatActors: List<RiScScenarioThreatActor>,
+    val vulnerabilities: List<RiScScenarioVulnerability>,
+    val risk: RiScScenarioRisk,
+    val remainingRisk: RiScScenarioRisk,
+    val actions: List<RiScScenarioAction>,
+)
+
+@Serializable
+enum class RiScScenarioThreatActor {
+    @SerialName("Script kiddie")
+    SCRIPT_KIDDIE,
+
+    @SerialName("Hacktivist")
+    HACKTIVIST,
+
+    @SerialName("Reckless employee")
+    RECKLESS_EMPLOYEE,
+
+    @SerialName("Insider")
+    INSIDER,
+
+    @SerialName("Organised crime")
+    ORGANISED_CRIME,
+
+    @SerialName("Terrorist organisation")
+    TERRORIST_ORGANISATION,
+
+    @SerialName("Nation/government")
+    NATION_OR_GOVERNMENT,
+}
+
+@Serializable
+enum class RiScScenarioVulnerability {
+    @SerialName("Flawed design")
+    FLAWED_DESIGN,
+
+    @SerialName("Misconfiguration")
+    MISCONFIGURATION,
+
+    @SerialName("Dependency vulnerability")
+    DEPENDENCY_VULNERABILITY,
+
+    @SerialName("Unauthorized access")
+    UNAUTHORIZED_ACCESS,
+
+    @SerialName("Unmonitored use")
+    UNMONITORED_USE,
+
+    @SerialName("Input tampering")
+    INPUT_TAMPERING,
+
+    @SerialName("Information leak")
+    INFORMATION_LEAK,
+
+    @SerialName("Excessive use")
+    EXCESSIVE_USE,
+}
+
+@Serializable
+data class RiScScenarioRisk(
+    val summary: String? = null,
+    val probability: Double,
+    val consequence: Double,
+)
+
+object RiScScenarioActionSerializer : FlattenSerializer<RiScScenarioAction>(
+    serializer = RiScScenarioAction.generatedSerializer(),
+    flattenKey = "action",
+    subKeys = listOf("ID", "url", "status"),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+@Serializable(with = RiScScenarioActionSerializer::class)
+data class RiScScenarioAction(
+    val title: String,
+    @SerialName("ID")
+    val id: String,
+    val url: String? = null,
+    val status: RiScScenarioActionStatus,
+)
+
+@Serializable
+enum class RiScScenarioActionStatus {
+    @SerialName("Not started")
+    NOT_STARTED,
+
+    @SerialName("In progress")
+    IN_PROGRESS,
+
+    @SerialName("On hold")
+    ON_HOLD,
+
+    @SerialName("Completed")
+    COMPLETED,
+
+    @SerialName("Aborted")
+    ABORTED,
+}

--- a/src/main/kotlin/no/risc/utils/JSONUtils.kt
+++ b/src/main/kotlin/no/risc/utils/JSONUtils.kt
@@ -20,6 +20,6 @@ val JSONPrettyPrintFormat =
 fun parseJSONToElement(jsonString: String): JsonElement = JSONIgnoreParser.parseToJsonElement(jsonString)
 
 /**
- * Serializes the provided JsonElement to a string, using a pretty print format.
+ * Serializes the provided serializable element to a string, using a pretty print format.
  */
-fun serializeJSON(jsonElement: JsonElement): String = JSONPrettyPrintFormat.encodeToString(jsonElement)
+inline fun <reified T> serializeJSON(element: T): String = JSONPrettyPrintFormat.encodeToString(element)

--- a/src/main/kotlin/no/risc/utils/Serializers.kt
+++ b/src/main/kotlin/no/risc/utils/Serializers.kt
@@ -1,10 +1,15 @@
 package no.risc.utils
+
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.jsonObject
 import java.text.SimpleDateFormat
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -32,4 +37,40 @@ class KDateSerializer : KSerializer<Date> {
     ) = encoder.encodeString(formatter.format(value))
 
     override fun deserialize(decoder: Decoder): Date = formatter.parse(decoder.decodeString())
+}
+
+/**
+ * A serializer for flattening the JSON based on a single key (`flattenKey`) to potentially multiple keys (`subKeys`) in
+ * the class T. For example, if the JSON looks like
+ * `{ "name": "Ola Nordmann", "extraInformation": { "age": 38, "occupation": "Developer" } }`
+ * we might want to have a class that looks like
+ * `data class Person(val name: String, val age: Int, val occupation: String)`.
+ * without modifying the JSON schema. This serializer allows for this by marking `Person` with `@KeepGeneratedSerializer`
+ * and `@Serializable(with = PersonSerializer::class)`, where we have
+ * `object PersonSerializer : FlattenSerializer<Person>(Person.generatedSerializer(), "extraInformation", listOf("age", "occupation"))`.
+ *
+ * @param serializer A serializer for the class T
+ * @param flattenKey The key to flatten
+ * @param subKeys The keys that belong to the flattened key
+ */
+open class FlattenSerializer<T>(
+    serializer: KSerializer<T>,
+    val flattenKey: String,
+    val subKeys: List<String>,
+) : JsonTransformingSerializer<T>(serializer) {
+    override fun transformDeserialize(element: JsonElement): JsonElement {
+        val jsonObject = element.jsonObject
+        return JsonObject(
+            jsonObject
+                .toMutableMap()
+                .minus(flattenKey)
+                .plus(jsonObject[flattenKey]!!.jsonObject.filterKeys { it in subKeys }),
+        )
+    }
+
+    override fun transformSerialize(element: JsonElement): JsonElement {
+        val jsonObject = element.jsonObject
+        val subObject = JsonObject(jsonObject.filterKeys { it in subKeys })
+        return JsonObject(jsonObject.toMutableMap().minus(subKeys).plus(flattenKey to subObject))
+    }
 }

--- a/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
@@ -1,6 +1,8 @@
 package no.risc.utils.comparison
 
 import kotlinx.serialization.Serializable
+import no.risc.risc.models.RiSc33ScenarioVulnerability
+import no.risc.risc.models.RiSc4XScenarioVulnerability
 
 data class MigrationChanges(
     val migrationChange40: MigrationChange40? = null,
@@ -19,7 +21,7 @@ data class MigrationChange40Scenario(
     val title: String,
     val id: String,
     val removedExistingActions: String? = null,
-    val changedVulnerabilities: List<MigrationChangedValue<String>>,
+    val changedVulnerabilities: List<MigrationChangedTypedValue<RiSc33ScenarioVulnerability, RiSc4XScenarioVulnerability>>,
     val changedActions: List<MigrationChange40Action>,
 )
 
@@ -58,5 +60,11 @@ data class MigrationChange41Scenario(
 @Serializable
 data class MigrationChangedValue<T>(
     val oldValue: T,
+    val newValue: T,
+)
+
+@Serializable
+data class MigrationChangedTypedValue<S, T>(
+    val oldValue: S,
     val newValue: T,
 )

--- a/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/MigrationDTOs.kt
@@ -43,9 +43,9 @@ data class MigrationChange41Scenario(
     val title: String,
     val id: String,
     var changedRiskProbability: MigrationChangedValue<Double>? = null,
-    var changedRiskConsequence: MigrationChangedValue<Int>? = null,
+    var changedRiskConsequence: MigrationChangedValue<Double>? = null,
     var changedRemainingRiskProbability: MigrationChangedValue<Double>? = null,
-    var changedRemainingRiskConsequence: MigrationChangedValue<Int>? = null,
+    var changedRemainingRiskConsequence: MigrationChangedValue<Double>? = null,
 ) {
     fun hasChanges() =
         changedRiskConsequence !== null ||

--- a/src/test/kotlin/no/risc/risc/models/RiScTests.kt
+++ b/src/test/kotlin/no/risc/risc/models/RiScTests.kt
@@ -1,0 +1,320 @@
+package no.risc.risc.models
+
+import kotlinx.serialization.json.Json
+import no.risc.validation.JSONValidator
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RiScTests {
+    fun riSc4XWithoutValuations(schemaVersion: String): RiSc4X =
+        RiSc4X(
+            schemaVersion = schemaVersion,
+            title = "Title",
+            scope = "Scope",
+            scenarios =
+                listOf(
+                    RiSc4XScenario(
+                        title = "Scenario with all attributes",
+                        id = "ABCDE",
+                        description = "Description",
+                        url = "https://example.org",
+                        threatActors =
+                            listOf(
+                                RiScScenarioThreatActor.HACKTIVIST,
+                                RiScScenarioThreatActor.INSIDER,
+                                RiScScenarioThreatActor.NATION_OR_GOVERNMENT,
+                                RiScScenarioThreatActor.ORGANISED_CRIME,
+                                RiScScenarioThreatActor.RECKLESS_EMPLOYEE,
+                                RiScScenarioThreatActor.SCRIPT_KIDDIE,
+                                RiScScenarioThreatActor.TERRORIST_ORGANISATION,
+                            ),
+                        vulnerabilities =
+                            listOf(
+                                RiSc4XScenarioVulnerability.EXCESSIVE_USE,
+                                RiSc4XScenarioVulnerability.INFORMATION_LEAK,
+                                RiSc4XScenarioVulnerability.UNAUTHORIZED_ACCESS,
+                                RiSc4XScenarioVulnerability.UNMONITORED_USE,
+                                RiSc4XScenarioVulnerability.INPUT_TAMPERING,
+                                RiSc4XScenarioVulnerability.MISCONFIGURATION,
+                                RiSc4XScenarioVulnerability.DEPENDENCY_VULNERABILITY,
+                                RiSc4XScenarioVulnerability.FLAWED_DESIGN,
+                            ),
+                        risk = RiScScenarioRisk(summary = "Text", probability = 1.0, consequence = 200_000.0),
+                        remainingRisk = RiScScenarioRisk(summary = "Text", probability = 0.025, consequence = 10_000.0),
+                        actions =
+                            listOf(
+                                RiSc4XScenarioAction(
+                                    title = "Title",
+                                    id = "12345",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.COMPLETED,
+                                ),
+                                RiSc4XScenarioAction(
+                                    title = "Title",
+                                    id = "23456",
+                                    description = "Description",
+                                    status = RiScScenarioActionStatus.ABORTED,
+                                ),
+                                RiSc4XScenarioAction(
+                                    title = "Title",
+                                    id = "34567",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.NOT_STARTED,
+                                ),
+                                RiSc4XScenarioAction(
+                                    title = "Title",
+                                    id = "45678",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.ON_HOLD,
+                                ),
+                                RiSc4XScenarioAction(
+                                    title = "Title",
+                                    id = "56789",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.IN_PROGRESS,
+                                ),
+                            ),
+                    ),
+                    RiSc4XScenario(
+                        title = "Scenario with minimum attributes",
+                        id = "ABCDE",
+                        description = "Description",
+                        threatActors = listOf(),
+                        vulnerabilities = listOf(),
+                        risk = RiScScenarioRisk(probability = 20.0, consequence = 40_000.0),
+                        remainingRisk = RiScScenarioRisk(probability = 0.13, consequence = 25_000.0),
+                        actions = listOf(),
+                    ),
+                ),
+        )
+
+    fun riSc4XWithValuations(schemaVersion: String): RiSc4X =
+        riSc4XWithoutValuations(schemaVersion).copy(
+            valuations =
+                listOf(
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.CONFIDENTIAL,
+                        integrity = RiScValuationIntegrity.CRITICAL,
+                        availability = RiScValuationAvailability.FOUR_HOURS,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.INTERNAL,
+                        integrity = RiScValuationIntegrity.INSIGNIFICANT,
+                        availability = RiScValuationAvailability.INSIGNIFICANT,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.PUBLIC,
+                        integrity = RiScValuationIntegrity.EXPECTED,
+                        availability = RiScValuationAvailability.IMMEDIATE,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.STRICTLY_CONFIDENTIAL,
+                        integrity = RiScValuationIntegrity.DEPENDENT,
+                        availability = RiScValuationAvailability.TWO_DAYS,
+                    ),
+                ),
+        )
+
+    @Test
+    fun `test that RiSc4X without valuations validates correctly for both versions 4-0 and 4-1`() {
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "4.0",
+                    riScContent = Json.encodeToString(riSc4XWithoutValuations("4.0")),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 4.0 when valuations are not present.",
+        )
+
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "4.1",
+                    riScContent = Json.encodeToString(riSc4XWithoutValuations("4.1")),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 4.1 when valuations are not present.",
+        )
+    }
+
+    @Test
+    fun `test that RiSc4X with valuations validates correctly for both versions 4-0 and 4-1`() {
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "4.0",
+                    riScContent = Json.encodeToString(riSc4XWithValuations("4.0")),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 4.0 when valuations are present.",
+        )
+
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "4.1",
+                    riScContent = Json.encodeToString(riSc4XWithValuations("4.1")),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 4.1 when valuations are present.",
+        )
+    }
+
+    val riSc33WithoutValuations =
+        RiSc33(
+            schemaVersion = "3.3",
+            title = "Title",
+            scope = "Scope",
+            scenarios =
+                listOf(
+                    RiSc33Scenario(
+                        title = "Scenario with all attributes",
+                        id = "ABCDE",
+                        description = "Description",
+                        url = "https://example.org",
+                        threatActors =
+                            listOf(
+                                RiScScenarioThreatActor.HACKTIVIST,
+                                RiScScenarioThreatActor.INSIDER,
+                                RiScScenarioThreatActor.NATION_OR_GOVERNMENT,
+                                RiScScenarioThreatActor.ORGANISED_CRIME,
+                                RiScScenarioThreatActor.RECKLESS_EMPLOYEE,
+                                RiScScenarioThreatActor.SCRIPT_KIDDIE,
+                                RiScScenarioThreatActor.TERRORIST_ORGANISATION,
+                            ),
+                        vulnerabilities =
+                            listOf(
+                                RiSc33ScenarioVulnerability.USER_REPUDIATION,
+                                RiSc33ScenarioVulnerability.INFORMATION_LEAK,
+                                RiSc33ScenarioVulnerability.DISCLOSED_SECRET,
+                                RiSc33ScenarioVulnerability.COMPROMISED_ADMIN_USER,
+                                RiSc33ScenarioVulnerability.INPUT_TAMPERING,
+                                RiSc33ScenarioVulnerability.MISCONFIGURATION,
+                                RiSc33ScenarioVulnerability.DEPENDENCY_VULNERABILITY,
+                                RiSc33ScenarioVulnerability.DENIAL_OF_SERVICE,
+                                RiSc33ScenarioVulnerability.ESCALATION_OF_RIGHTS,
+                            ),
+                        risk = RiScScenarioRisk(summary = "Text", probability = 1.0, consequence = 200_000.0),
+                        remainingRisk = RiScScenarioRisk(summary = "Text", probability = 0.025, consequence = 10_000.0),
+                        actions =
+                            listOf(
+                                RiSc33ScenarioAction(
+                                    title = "Title",
+                                    id = "12345",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.COMPLETED,
+                                    owner = "Ola Nordmann",
+                                    deadline = "2024-12-12",
+                                ),
+                                RiSc33ScenarioAction(
+                                    title = "Title",
+                                    id = "23456",
+                                    description = "Description",
+                                    status = RiScScenarioActionStatus.ABORTED,
+                                    owner = "Ola Nordmann",
+                                ),
+                                RiSc33ScenarioAction(
+                                    title = "Title",
+                                    id = "34567",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.NOT_STARTED,
+                                    deadline = "2020-10-10",
+                                ),
+                                RiSc33ScenarioAction(
+                                    title = "Title",
+                                    id = "45678",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.ON_HOLD,
+                                ),
+                                RiSc33ScenarioAction(
+                                    title = "Title",
+                                    id = "56789",
+                                    description = "Description",
+                                    url = "https://example.org",
+                                    status = RiScScenarioActionStatus.IN_PROGRESS,
+                                ),
+                            ),
+                        existingActions = "Existing actions",
+                    ),
+                    RiSc33Scenario(
+                        title = "Scenario with minimum attributes",
+                        id = "ABCDE",
+                        description = "Description",
+                        threatActors = listOf(),
+                        vulnerabilities = listOf(),
+                        risk = RiScScenarioRisk(probability = 20.0, consequence = 40_000.0),
+                        remainingRisk = RiScScenarioRisk(probability = 0.13, consequence = 25_000.0),
+                        actions = listOf(),
+                    ),
+                ),
+        )
+
+    val riSc33WithValuations =
+        riSc33WithoutValuations.copy(
+            valuations =
+                listOf(
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.CONFIDENTIAL,
+                        integrity = RiScValuationIntegrity.CRITICAL,
+                        availability = RiScValuationAvailability.FOUR_HOURS,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.INTERNAL,
+                        integrity = RiScValuationIntegrity.INSIGNIFICANT,
+                        availability = RiScValuationAvailability.INSIGNIFICANT,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.PUBLIC,
+                        integrity = RiScValuationIntegrity.EXPECTED,
+                        availability = RiScValuationAvailability.IMMEDIATE,
+                    ),
+                    RiScValuation(
+                        description = "Description",
+                        confidentiality = RiScValuationConfidentiality.STRICTLY_CONFIDENTIAL,
+                        integrity = RiScValuationIntegrity.DEPENDENT,
+                        availability = RiScValuationAvailability.TWO_DAYS,
+                    ),
+                ),
+        )
+
+    @Test
+    fun `test that RiSc33 without valuations validates correctly`() {
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "3.3",
+                    riScContent = Json.encodeToString(riSc33WithoutValuations),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 3.3 when valuations are not present.",
+        )
+    }
+
+    @Test
+    fun `test that RiSc33 with valuations validates correctly`() {
+        assertTrue(
+            JSONValidator
+                .validateAgainstSchema(
+                    riScId = "abcde",
+                    schema = "3.3",
+                    riScContent = Json.encodeToString(riSc33WithValuations),
+                ).isValid,
+            "All choices of missing or present attributes in the RiSc model should validate correctly with the JSON schema for version 3.3 when valuations are present.",
+        )
+    }
+}

--- a/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
@@ -257,7 +257,7 @@ class MigrationFunctionTests {
 
         fun testConsequenceAndProbability(
             risk: JsonObject?,
-            expectedConsequence: Int,
+            expectedConsequence: Number,
             expectedProbability: Number,
         ) {
             val consequence = risk?.get("consequence")?.jsonPrimitive?.content
@@ -277,18 +277,18 @@ class MigrationFunctionTests {
         assertEquals(scenariosJsonObjects?.size, 3)
 
         scenariosJsonObjects?.get(0)?.let {
-            testConsequenceAndProbability(it["risk"]?.jsonObject, 160_000, 0.05)
-            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 8_000, 0.0025)
+            testConsequenceAndProbability(it["risk"]?.jsonObject, 160_000.0, 0.05)
+            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 8_000.0, 0.0025)
         }
         scenariosJsonObjects?.get(1)?.let {
-            testConsequenceAndProbability(it["risk"]?.jsonObject, 64_000_000, 20.0)
-            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 3_200_000, 1.0)
+            testConsequenceAndProbability(it["risk"]?.jsonObject, 64_000_000.0, 20.0)
+            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 3_200_000.0, 1.0)
         }
         scenariosJsonObjects?.get(2)?.let {
-            testConsequenceAndProbability(it["risk"]?.jsonObject, 1_280_000_000, 400.0)
+            testConsequenceAndProbability(it["risk"]?.jsonObject, 1_280_000_000.0, 400.0)
 
             // Specific values not equal to the preset values should not be changed
-            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 198_000, 0.123)
+            testConsequenceAndProbability(it["remainingRisk"]?.jsonObject, 198_000.0, 0.123)
         }
 
         assertEquals(true, migratedObject.migrationStatus.migrationChanges)
@@ -308,9 +308,9 @@ class MigrationFunctionTests {
                 title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
                 id = "14Kap",
                 changedRiskProbability = MigrationChangedValue(0.1, 0.05),
-                changedRiskConsequence = MigrationChangedValue(30_000, 160_000),
+                changedRiskConsequence = MigrationChangedValue(30_000.0, 160_000.0),
                 changedRemainingRiskProbability = MigrationChangedValue(0.01, 0.0025),
-                changedRemainingRiskConsequence = MigrationChangedValue(1_000, 8_000),
+                changedRemainingRiskConsequence = MigrationChangedValue(1_000.0, 8_000.0),
             )
 
         assertEquals(
@@ -324,8 +324,8 @@ class MigrationFunctionTests {
                 title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
                 id = "25FcD",
                 changedRiskProbability = MigrationChangedValue(50.0, 20.0),
-                changedRiskConsequence = MigrationChangedValue(30_000_000, 64_000_000),
-                changedRemainingRiskConsequence = MigrationChangedValue(1_000_000, 3_200_000),
+                changedRiskConsequence = MigrationChangedValue(30_000_000.0, 64_000_000.0),
+                changedRemainingRiskConsequence = MigrationChangedValue(1_000_000.0, 3_200_000.0),
             )
 
         assertEquals(
@@ -339,7 +339,7 @@ class MigrationFunctionTests {
                 title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
                 id = "2dsFd",
                 changedRiskProbability = MigrationChangedValue(300.0, 400.0),
-                changedRiskConsequence = MigrationChangedValue(1_000_000_000, 1_280_000_000),
+                changedRiskConsequence = MigrationChangedValue(1_000_000_000.0, 1_280_000_000.0),
             )
 
         assertEquals(
@@ -414,8 +414,8 @@ class MigrationFunctionTests {
                         MigrationChange41Scenario(
                             title = "Ondsinnet bruker ønsker å ta ned løsningen. ",
                             id = "14Kap",
-                            changedRiskConsequence = MigrationChangedValue(1_000, 8_000),
-                            changedRemainingRiskConsequence = MigrationChangedValue(1_000, 8_000),
+                            changedRiskConsequence = MigrationChangedValue(1_000.0, 8_000.0),
+                            changedRemainingRiskConsequence = MigrationChangedValue(1_000.0, 8_000.0),
                             changedRemainingRiskProbability = MigrationChangedValue(0.1, 0.05),
                         ),
                     ),

--- a/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import no.risc.risc.models.ContentStatus
 import no.risc.risc.models.MigrationStatus
 import no.risc.risc.models.MigrationVersions
+import no.risc.risc.models.RiSc33ScenarioVulnerability
+import no.risc.risc.models.RiSc4XScenarioVulnerability
 import no.risc.risc.models.RiScContentResultDTO
 import no.risc.risc.models.RiScStatus
 import no.risc.utils.comparison.MigrationChange40
@@ -15,6 +17,7 @@ import no.risc.utils.comparison.MigrationChange40Action
 import no.risc.utils.comparison.MigrationChange40Scenario
 import no.risc.utils.comparison.MigrationChange41
 import no.risc.utils.comparison.MigrationChange41Scenario
+import no.risc.utils.comparison.MigrationChangedTypedValue
 import no.risc.utils.comparison.MigrationChangedValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -177,11 +180,26 @@ class MigrationFunctionTests {
 
         val expectedChanges =
             listOf(
-                MigrationChangedValue("User repudiation", "Unmonitored use"),
-                MigrationChangedValue("Compromised admin user", "Unauthorized access"),
-                MigrationChangedValue("Escalation of rights", "Unauthorized access"),
-                MigrationChangedValue("Disclosed secret", "Information leak"),
-                MigrationChangedValue("Denial of service", "Excessive use"),
+                MigrationChangedTypedValue(
+                    RiSc33ScenarioVulnerability.USER_REPUDIATION,
+                    RiSc4XScenarioVulnerability.UNMONITORED_USE,
+                ),
+                MigrationChangedTypedValue(
+                    RiSc33ScenarioVulnerability.COMPROMISED_ADMIN_USER,
+                    RiSc4XScenarioVulnerability.UNAUTHORIZED_ACCESS,
+                ),
+                MigrationChangedTypedValue(
+                    RiSc33ScenarioVulnerability.ESCALATION_OF_RIGHTS,
+                    RiSc4XScenarioVulnerability.UNAUTHORIZED_ACCESS,
+                ),
+                MigrationChangedTypedValue(
+                    RiSc33ScenarioVulnerability.DISCLOSED_SECRET,
+                    RiSc4XScenarioVulnerability.INFORMATION_LEAK,
+                ),
+                MigrationChangedTypedValue(
+                    RiSc33ScenarioVulnerability.DENIAL_OF_SERVICE,
+                    RiSc4XScenarioVulnerability.EXCESSIVE_USE,
+                ),
             )
 
         assertTrue(
@@ -387,7 +405,10 @@ class MigrationFunctionTests {
                             removedExistingActions = "Ddos protection. ",
                             changedVulnerabilities =
                                 listOf(
-                                    MigrationChangedValue("Denial of service", "Excessive use"),
+                                    MigrationChangedTypedValue(
+                                        RiSc33ScenarioVulnerability.DENIAL_OF_SERVICE,
+                                        RiSc4XScenarioVulnerability.EXCESSIVE_USE,
+                                    ),
                                 ),
                             changedActions =
                                 listOf(

--- a/src/test/resources/3.3-no-scenarios.json
+++ b/src/test/resources/3.3-no-scenarios.json
@@ -2,5 +2,6 @@
   "schemaVersion": "3.3",
   "title": "Transformasjon",
   "scope": "Sikkerhet av backend.",
-  "valuations": []
+  "valuations": [],
+  "scenarios": []
 }


### PR DESCRIPTION
Adds RiSc models for schema version `3.3` and `4.X`. The models allow for encoding/decoding to JSON.

Currently, the models are only used to simplify migrations. In the future, they models will be used to improve the comparison functionality used for displaying the changes to the RiSc since last publication.