### PR TITLE
Add Spring Boot DevTools for hot reload support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation("io.mockk:mockk:$mockkVersion")
+
+    developmentOnly("org.springframework.boot:spring-boot-devtools:$springBootVersion")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## Summary
- Added `spring-boot-devtools` dependency to enable hot reload during development
- Improves developer experience when using the ✨Local Server run configuration

## Test plan
- Start application using ✨Local Server configuration  
- Make code changes and verify automatic restart occurs