### PR TITLE
Feedback endpoint fixes

### DIFF
--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -210,7 +210,7 @@ class RiScController(
         return ResponseEntity.ok().body(difference)
     }
 
-    @PostMapping("/{repositoryOwner}/{repositoryName}/feedback")
+    @PostMapping("/{repositoryOwner}/{repositoryName}/feedback", produces = ["application/json"])
     suspend fun sendFeedback(
         @RequestBody feedbackMessage: String,
         @PathVariable repositoryOwner: String,

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -215,11 +215,11 @@ class RiScController(
         @RequestBody feedbackMessage: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
-    ): ResponseEntity<String> =
+    ): ResponseEntity<Map<String, String>> =
         try {
             slackService.sendFeedback(feedbackMessage)
-            ResponseEntity.ok("{}")
+            ResponseEntity.ok(emptyMap())
         } catch (e: Exception) {
-            ResponseEntity.status(500).body("Failed to send feedback to Slack")
+            ResponseEntity.status(500).body(mapOf("error" to "Failed to send feedback to Slack"))
         }
 }

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -215,7 +215,7 @@ class RiScController(
         @RequestBody feedbackMessage: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
-    ): ResponseEntity<*> =
+    ): ResponseEntity<String> =
         try {
             slackService.sendFeedback(feedbackMessage)
             ResponseEntity.ok("{}")


### PR DESCRIPTION
- added produces = [application/json] to feedback endpoint
- returning empty json object instead of string in feedback endpoint