### PR TITLE
Set commons-lang3 dependency constraint to 3.18.0 to fix vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,12 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation("io.mockk:mockk:$mockkVersion")
+
+    constraints {
+        implementation("org.apache.commons:commons-lang3:3.18.0") {
+            because("Force secure version to fix CVE in transitive dependency from spring-boot-gradle-plugin")
+        }
+    }
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
Fixes https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/security/dependabot/47