### PR TITLE
Set netty-codec-http2 dependency constraint to 4.1.124.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
         implementation("org.apache.commons:commons-lang3:3.18.0") {
             because("Force secure version to fix CVE in transitive dependency from spring-boot-gradle-plugin")
         }
+        implementation("io.netty:netty-codec-http2:4.1.124.Final") {
+            because("Force specific version for transitive dependency")
+        }
     }
 }
 


### PR DESCRIPTION
Added dependency constraint for io.netty:netty-codec-http2 to version 4.1.124.Final