### PR TITLE
MVP - Adding print-statement to notify about branch deletion

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -782,7 +782,8 @@ class GithubConnector(
                                 } else {
                                     "The risk scorecard has been updated, but does not require new approval."
                                 }
-                            ) + " Merge the pull request to include the changes in the default branch.",
+                            ) + "Merge the pull request to include the changes in the default branch. +" +
+                                "\nMake sure to delete the branch after merging if auto-deletion is not enabled for your repository",
                         branch = riScId,
                         baseBranch = baseBranchDeferred.await(),
                     ),

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -782,7 +782,7 @@ class GithubConnector(
                                 } else {
                                     "The risk scorecard has been updated, but does not require new approval."
                                 }
-                            ) + "Merge the pull request to include the changes in the default branch. +" +
+                            ) + "Merge the pull request to include the changes in the default branch." +
                                 "\nMake sure to delete the branch after merging if auto-deletion is not enabled for your repository",
                         branch = riScId,
                         baseBranch = baseBranchDeferred.await(),


### PR DESCRIPTION
MVP - Further iterations could update the UI but for now the commit message is updated to notify the user about branch-deletion after merge.

<img width="758" height="329" alt="Screenshot 2025-09-01 at 12 43 26" src="https://github.com/user-attachments/assets/74d2eb25-3fd0-40a2-bfff-ff2e7260ea3f" />

