### PR TITLE
Fixed nullable date deserialization to allow fetching more RiScs

### DIFF
--- a/src/main/kotlin/no/risc/utils/Serializers.kt
+++ b/src/main/kotlin/no/risc/utils/Serializers.kt
@@ -52,7 +52,7 @@ class KNullableOffsetDateTimeSerializer : KSerializer<OffsetDateTime?> {
             } else {
                 return decoder.decodeNull()
             }
-        } catch (e: DateTimeParseException) {
+        } catch (_: DateTimeParseException) {
             return null
         }
     }

--- a/src/main/kotlin/no/risc/utils/Serializers.kt
+++ b/src/main/kotlin/no/risc/utils/Serializers.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.jsonObject
 import java.text.SimpleDateFormat
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Date
 
 class KOffsetDateTimeSerializer : KSerializer<OffsetDateTime> {
@@ -44,12 +45,17 @@ class KNullableOffsetDateTimeSerializer : KSerializer<OffsetDateTime?> {
         }
     }
 
-    override fun deserialize(decoder: Decoder): OffsetDateTime? =
-        if (decoder.decodeNotNullMark()) {
-            delegate.deserialize(decoder)
-        } else {
-            decoder.decodeNull()
+    override fun deserialize(decoder: Decoder): OffsetDateTime? {
+        try {
+            if (decoder.decodeNotNullMark()) {
+                return delegate.deserialize(decoder)
+            } else {
+                return decoder.decodeNull()
+            }
+        } catch (e: DateTimeParseException) {
+            return null
         }
+    }
 }
 
 class KDateSerializer : KSerializer<Date> {


### PR DESCRIPTION
# Before
### Riscs not fetchable:
<img width="680" height="88" alt="Screenshot 2025-09-04 at 13 21 44" src="https://github.com/user-attachments/assets/53ba8266-9239-455d-93d5-85f5414cee2a" />

### Trying to fetch risc-zb7B8:
<img width="682" height="60" alt="image" src="https://github.com/user-attachments/assets/81967df4-05c1-402a-a751-1f93446008b4" />


# After
### Riscs not fetchable (fewer than before):
<img width="687" height="93" alt="Screenshot 2025-09-04 at 13 21 59" src="https://github.com/user-attachments/assets/8b2277dc-054a-406d-95d0-c2e099bed1dd" />

### Now risc-zb7B8 is displayable in the UI because of the change:
<img width="948" height="1129" alt="image" src="https://github.com/user-attachments/assets/e253578b-4b12-4625-b3e4-16715415bb53" />