### PR TITLE
Corrected the algorithm for calculating RiSc statuses to prevent bugs

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -169,11 +169,11 @@ class GithubConnector(
      * @param repository The repository to fetch RiSc identifiers from.
      * @param githubAccessToken The GitHub access token to use for authorization.
      */
-    suspend fun fetchRiScMetadata(
+    suspend fun fetchRiScGithubMetadata(
         owner: String,
         repository: String,
         githubAccessToken: GithubAccessToken
-    ): List<RiScMetadata> =
+    ): List<RiScGithubMetadata> =
         coroutineScope {
             val riscIdsFromMainFiles = async(Dispatchers.IO) {
                 fetchPublishedRiScIdentifiers(owner, repository, githubAccessToken.value)
@@ -197,7 +197,7 @@ class GithubConnector(
             val prUrls: Map<String, String?> = riscIdsWithPR.await().associate { it.id to it.pullRequestUrl }
 
             allIds.map { id ->
-                RiScMetadata(
+                RiScGithubMetadata(
                     id = id,
                     isStoredInMain = id in mainIds,
                     hasBranch = id in branchIds,

--- a/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
+++ b/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
@@ -1,0 +1,108 @@
+package no.risc.github
+import no.risc.github.models.GithubContentResponse
+import no.risc.github.models.GithubStatus
+import no.risc.risc.models.RiScStatus
+
+enum class RiscBranchState {
+    DOES_NOT_EXIST,
+    EXISTS_WITH_SAME_FILE,
+    EXISTS_WITHOUT_FILE,
+    EXISTS_WITH_DIFFERENT_FILE,
+}
+
+enum class MainBranchState {
+    HAS_FILE,
+    NO_FILE,
+}
+
+enum class PRState {
+    OPEN,
+    NONE
+}
+
+data class RiscState(var mainBranchState: MainBranchState, var riscBranchState: RiscBranchState, var prState: PRState)
+
+data class RiScMetadata(
+    val id: String,
+    val isStoredInMain: Boolean,
+    val hasBranch: Boolean,
+    val hasOpenPR: Boolean,
+    val prUrl: String?
+)
+
+data class RiScMainAndBranchContent(val mainContent: GithubContentResponse, val branchContent: GithubContentResponse)
+
+fun fromRiscStateToStatus(state: RiscState): RiScStatus {
+    if (state.mainBranchState == MainBranchState.HAS_FILE) {
+        return when (state.riscBranchState) {
+            RiscBranchState.DOES_NOT_EXIST -> RiScStatus.Published
+            RiscBranchState.EXISTS_WITH_SAME_FILE -> RiScStatus.Published
+            RiscBranchState.EXISTS_WITHOUT_FILE ->
+                if (state.prState == PRState.OPEN) RiScStatus.DeletionSentForApproval else RiScStatus.DeletionDraft
+            RiscBranchState.EXISTS_WITH_DIFFERENT_FILE ->
+                if (state.prState == PRState.OPEN) RiScStatus.SentForApproval else RiScStatus.Draft
+        }
+    } else {
+        return when (state.riscBranchState) {
+            RiscBranchState.DOES_NOT_EXIST -> RiScStatus.Deleted
+            RiscBranchState.EXISTS_WITH_SAME_FILE -> RiScStatus.Deleted
+            RiscBranchState.EXISTS_WITHOUT_FILE -> RiScStatus.Deleted
+            RiscBranchState.EXISTS_WITH_DIFFERENT_FILE ->
+                if (state.prState == PRState.OPEN)
+                    RiScStatus.SentForApproval
+                else
+                    RiScStatus.Draft
+        }
+    }
+}
+
+fun chooseRiScContentFromStatus(
+    status: RiScStatus,
+    branchRiScContent: GithubContentResponse,
+    mainRiscContent: GithubContentResponse): GithubContentResponse {
+    return when (status) {
+        RiScStatus.SentForApproval, RiScStatus.Draft -> branchRiScContent
+        RiScStatus.Published, RiScStatus.DeletionDraft, RiScStatus.DeletionSentForApproval -> mainRiscContent
+        else -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
+    }
+}
+
+fun getMainState(riScMetadata: RiScMetadata): MainBranchState {
+    if (riScMetadata.isStoredInMain) return MainBranchState.HAS_FILE
+    return MainBranchState.NO_FILE
+}
+
+fun getBranchState(
+    riScMetadata: RiScMetadata,
+    branchRiscContent: GithubContentResponse,
+    mainRiscContent: GithubContentResponse): RiscBranchState {
+
+    if (!riScMetadata.hasBranch) return RiscBranchState.DOES_NOT_EXIST
+    if (branchRiscContent.status != GithubStatus.Success) return RiscBranchState.EXISTS_WITHOUT_FILE
+
+    if (mainRiscContent.status == GithubStatus.Success) {
+        // Risc exists in both branches
+        if (mainRiscContent.data == branchRiscContent.data) return RiscBranchState.EXISTS_WITH_SAME_FILE
+        return RiscBranchState.EXISTS_WITH_DIFFERENT_FILE
+    }
+    return RiscBranchState.EXISTS_WITH_DIFFERENT_FILE
+
+}
+
+fun getPRState(riScMetadata: RiScMetadata): PRState {
+    if (riScMetadata.hasOpenPR) return PRState.OPEN
+    return PRState.NONE
+}
+
+fun getRiScStatus(
+    riScMetadata: RiScMetadata,
+    mainRiscContent: GithubContentResponse,
+    branchRiscContent: GithubContentResponse
+): RiScStatus {
+    val state = RiscState(
+        getMainState(riScMetadata),
+        getBranchState(riScMetadata, branchRiscContent, mainRiscContent),
+        getPRState(riScMetadata)
+    )
+    return fromRiscStateToStatus(state)
+}

--- a/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
+++ b/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
@@ -3,26 +3,7 @@ import no.risc.github.models.GithubContentResponse
 import no.risc.github.models.GithubStatus
 import no.risc.risc.models.RiScStatus
 
-enum class RiscBranchState {
-    DOES_NOT_EXIST,
-    EXISTS_WITH_SAME_FILE,
-    EXISTS_WITHOUT_FILE,
-    EXISTS_WITH_DIFFERENT_FILE,
-}
-
-enum class MainBranchState {
-    HAS_FILE,
-    NO_FILE,
-}
-
-enum class PRState {
-    OPEN,
-    NONE
-}
-
-data class RiscState(var mainBranchState: MainBranchState, var riscBranchState: RiscBranchState, var prState: PRState)
-
-data class RiScMetadata(
+data class RiScGithubMetadata(
     val id: String,
     val isStoredInMain: Boolean,
     val hasBranch: Boolean,
@@ -32,7 +13,54 @@ data class RiScMetadata(
 
 data class RiScMainAndBranchContent(val mainContent: GithubContentResponse, val branchContent: GithubContentResponse)
 
-fun fromRiscStateToStatus(state: RiscState): RiScStatus {
+fun chooseRiScContentFromStatus(
+    status: RiScStatus,
+    branchRiScContent: GithubContentResponse,
+    mainRiscContent: GithubContentResponse): GithubContentResponse {
+    return when (status) {
+        RiScStatus.SentForApproval, RiScStatus.Draft -> branchRiScContent
+        RiScStatus.Published, RiScStatus.DeletionDraft, RiScStatus.DeletionSentForApproval -> mainRiscContent
+        else -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
+    }
+}
+
+fun getRiScStatus(
+    riScGithubMetadata: RiScGithubMetadata,
+    mainRiscContent: GithubContentResponse,
+    branchRiscContent: GithubContentResponse
+): RiScStatus {
+    val state = RiscGithubBranchesState(
+        getMainState(riScGithubMetadata),
+        getBranchState(riScGithubMetadata, branchRiscContent, mainRiscContent),
+        getPRState(riScGithubMetadata)
+    )
+    return fromRiScGithubStateToStatus(state)
+}
+
+private enum class RiscBranchState {
+    DOES_NOT_EXIST,
+    EXISTS_WITH_SAME_FILE,
+    EXISTS_WITHOUT_FILE,
+    EXISTS_WITH_DIFFERENT_FILE,
+}
+
+private enum class MainBranchState {
+    HAS_FILE,
+    NO_FILE,
+}
+
+private enum class PRState {
+    OPEN,
+    NONE
+}
+
+private data class RiscGithubBranchesState(
+    val mainBranchState: MainBranchState,
+    val riscBranchState: RiscBranchState,
+    val prState: PRState
+)
+
+private fun fromRiScGithubStateToStatus(state: RiscGithubBranchesState): RiScStatus {
     if (state.mainBranchState == MainBranchState.HAS_FILE) {
         return when (state.riscBranchState) {
             RiscBranchState.DOES_NOT_EXIST -> RiScStatus.Published
@@ -56,28 +84,17 @@ fun fromRiscStateToStatus(state: RiscState): RiScStatus {
     }
 }
 
-fun chooseRiScContentFromStatus(
-    status: RiScStatus,
-    branchRiScContent: GithubContentResponse,
-    mainRiscContent: GithubContentResponse): GithubContentResponse {
-    return when (status) {
-        RiScStatus.SentForApproval, RiScStatus.Draft -> branchRiScContent
-        RiScStatus.Published, RiScStatus.DeletionDraft, RiScStatus.DeletionSentForApproval -> mainRiscContent
-        else -> GithubContentResponse(null, GithubStatus.ContentIsEmpty)
-    }
-}
-
-fun getMainState(riScMetadata: RiScMetadata): MainBranchState {
-    if (riScMetadata.isStoredInMain) return MainBranchState.HAS_FILE
+private fun getMainState(riScGithubMetadata: RiScGithubMetadata): MainBranchState {
+    if (riScGithubMetadata.isStoredInMain) return MainBranchState.HAS_FILE
     return MainBranchState.NO_FILE
 }
 
-fun getBranchState(
-    riScMetadata: RiScMetadata,
+private fun getBranchState(
+    riScGithubMetadata: RiScGithubMetadata,
     branchRiscContent: GithubContentResponse,
     mainRiscContent: GithubContentResponse): RiscBranchState {
 
-    if (!riScMetadata.hasBranch) return RiscBranchState.DOES_NOT_EXIST
+    if (!riScGithubMetadata.hasBranch) return RiscBranchState.DOES_NOT_EXIST
     if (branchRiscContent.status != GithubStatus.Success) return RiscBranchState.EXISTS_WITHOUT_FILE
 
     if (mainRiscContent.status == GithubStatus.Success) {
@@ -89,20 +106,7 @@ fun getBranchState(
 
 }
 
-fun getPRState(riScMetadata: RiScMetadata): PRState {
-    if (riScMetadata.hasOpenPR) return PRState.OPEN
+private fun getPRState(riScGithubMetadata: RiScGithubMetadata): PRState {
+    if (riScGithubMetadata.hasOpenPR) return PRState.OPEN
     return PRState.NONE
-}
-
-fun getRiScStatus(
-    riScMetadata: RiScMetadata,
-    mainRiscContent: GithubContentResponse,
-    branchRiscContent: GithubContentResponse
-): RiScStatus {
-    val state = RiscState(
-        getMainState(riScMetadata),
-        getBranchState(riScMetadata, branchRiscContent, mainRiscContent),
-        getPRState(riScMetadata)
-    )
-    return fromRiscStateToStatus(state)
 }

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -42,7 +42,7 @@ class RiScController(
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
     ): List<RiScContentResultDTO> =
-        riScService.fetchAllRiScs(
+        riScService.fetchAllRiScsV2(
             owner = repositoryOwner,
             repository = repositoryName,
             accessTokens =

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -61,17 +61,16 @@ class RiScController(
         @PathVariable repositoryName: String,
         @PathVariable latestSupportedVersion: String,
     ): List<RiScContentResultDTO> {
-        val result =
-            riScService.fetchAllRiScs(
-                owner = repositoryOwner,
-                repository = repositoryName,
-                accessTokens =
-                    AccessTokens(
-                        gcpAccessToken = GCPAccessToken(gcpAccessToken),
-                        githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
-                    ),
-                latestSupportedVersion = latestSupportedVersion,
-            )
+        val result = riScService.fetchAllRiScsV2(
+            owner = repositoryOwner,
+            repository = repositoryName,
+            accessTokens =
+                AccessTokens(
+                    gcpAccessToken = GCPAccessToken(gcpAccessToken),
+                    githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
+                ),
+            latestSupportedVersion = latestSupportedVersion
+        )
         return result
     }
 

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -11,7 +11,7 @@ import no.risc.exception.exceptions.RiScNotValidOnUpdateException
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.UpdatingRiScException
 import no.risc.github.GithubConnector
-import no.risc.github.RiScMetadata
+import no.risc.github.RiScGithubMetadata
 import no.risc.github.chooseRiScContentFromStatus
 import no.risc.github.getRiScStatus
 import no.risc.github.models.GithubContentResponse
@@ -250,9 +250,13 @@ class RiScService(
 
     suspend fun fetchAllRiScsV2(owner: String, repository: String, accessTokens: AccessTokens, latestSupportedVersion: String) : List<RiScContentResultDTO> =
         coroutineScope {
-            val riScMetadataList: List<RiScMetadata> = githubConnector.fetchRiScMetadata(owner, repository, accessTokens.githubAccessToken)
+            val riScGithubMetadataList: List<RiScGithubMetadata> = githubConnector.fetchRiScGithubMetadata(
+                owner,
+                repository,
+                accessTokens.githubAccessToken
+            )
 
-            riScMetadataList.map { riScMetadata ->
+            riScGithubMetadataList.map { riScMetadata ->
                 async(Dispatchers.IO) {
                     val riScContents = githubConnector.fetchBranchAndMainRiScContent(
                         riScMetadata.id,

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -248,6 +248,18 @@ class RiScService(
                 }
         }
 
+    /**
+     * Fetches all RiScs in the given repository. There are three types, drafts (RiScs that have pending updates), sent
+     * for approval (RiScs that have pending pull requests) and published (RiScs that have been approved, i.e., appear
+     * in the default branch of the repository). If there exists multiple version of a RiSc with the same ID, they are
+     * prioritised to return the most updated RiSc. Each fetched RiSc is migrated to the latest supported version and
+     * validated against the JSON schema of their version.
+     *
+     * @param owner The user/organisation the repository belongs to.
+     * @param repository The repository to fetch RiScs from.
+     * @param accessTokens The access tokens to use for authorization.
+     * @param latestSupportedVersion The RiSc schema version to migrate the RiScs to if not already or past this version.
+     */
     suspend fun fetchAllRiScsV2(owner: String, repository: String, accessTokens: AccessTokens, latestSupportedVersion: String) : List<RiScContentResultDTO> =
         coroutineScope {
             val riScGithubMetadataList: List<RiScGithubMetadata> = githubConnector.fetchRiScGithubMetadata(

--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -187,6 +187,7 @@ enum class RiScStatus {
     Published,
     DeletionDraft,
     DeletionSentForApproval,
+    Deleted
 }
 
 @Serializable


### PR DESCRIPTION
# Purpose of this PR  
Because this represents a significant change, the goal of this PR is to gather feedback on the new algorithm before proceeding with test updates and code cleanup.

## Next steps before merging  
- Remove obsolete code from the old algorithm  
- Update tests to cover the new algorithm  

Once these tasks are completed, a follow-up PR will be opened.  

# Problem  the PR Addresses
The current algorithm for fetching RiScs fails to handle cases where a RiSc is modified (deleted or edited) and merged into the main branch, but the corresponding RiSc branch is left undeleted. This leads to incorrect status values being assigned to RiScs.  

## Example 1: Deleted RiSc not recognized  
If a user deletes a RiSc but forgets to delete the RiSc branch, the algorithm still attempts to fetch it, since it doesn’t recognize that it was deleted.  

<img width="676" height="44" alt="image" src="https://github.com/user-attachments/assets/f600a996-fbc9-437e-98fd-05c6208b852f" />  

In the example above, the RiScs inside the red box have been deleted and should not be fetched.  

## Example 2: Published RiSc misclassified as Draft  
If a user edits and merges a RiSc but leaves the RiSc branch undeleted, the RiSc incorrectly receives the status **“Draft”** instead of **“Published.”** When clicking **Accept Risks**, the following is shown:  

<img width="719" height="341" alt="image" src="https://github.com/user-attachments/assets/75dfcf86-c169-4f58-9ba7-082a7ddddffe" />  

# Solution (this PR)  
This PR introduces a new algorithm for determining the status of RiScs. Instead of relying solely on the existence of a branch, the new algorithm compares the content of the RiSc on the main branch with the content on the RiSc branch (if it exists). This makes it possible to reliably determine the actual status of a RiSc.  

While this approach may sound more resource-intensive, initial testing shows it performs as fast—or even faster—than the current algorithm.

Also note that the new algorithm reuses a lot from the current.

## How the solution addresses Example 1:
The new algorithm does not try to fetch deleted riscs:
<img width="459" height="73" alt="image" src="https://github.com/user-attachments/assets/a917db57-453c-4d88-8a35-0c060f5b7370" />

## How the solution addresses Example 2:
The status of the RiSc showed in Example 2 will be "Published":
<img width="824" height="177" alt="image" src="https://github.com/user-attachments/assets/148c2e50-a90e-41c8-bf2f-f0e00994d773" />

