### PR TITLE
Allow users to choose between different types of initial RiScs

### DIFF
--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -3,6 +3,7 @@ package no.risc.initRiSc
 import no.risc.exception.exceptions.SopsConfigGenerateFetchException
 import no.risc.infra.connector.InitRiScServiceConnector
 import no.risc.initRiSc.model.GenerateRiScRequestBody
+import no.risc.risc.models.DefaultRiScType
 import no.risc.risc.models.ProcessRiScResultDTO
 import no.risc.risc.models.ProcessingStatus
 import org.springframework.stereotype.Component
@@ -19,12 +20,19 @@ class InitRiScServiceIntegration(
      *
      * @param initialRiSc A JSON serialized RiSc to base the default RiSc on. Must include the `title` and `scope`
      *                    fields. These are the only fields used from `initialRiSc`.
+     *
+     * @param defaultRiScTypes A list of predefined default RiSc types to generate the RiSc from. Currently, only a
+     *                         single default RiSc is supported. Therefore, the first RiSc from the defaultRiScTypes
+     *                         list is selected for the RiSc generation.
      */
-    suspend fun generateDefaultRiSc(initialRiSc: String): String =
+    suspend fun generateDefaultRiSc(
+        initialRiSc: String,
+        defaultRiScTypes: List<DefaultRiScType>,
+    ): String =
         initRiScServiceConnector.webClient
             .post()
             .uri("/generate")
-            .body(BodyInserters.fromValue(GenerateRiScRequestBody(initialRiSc)))
+            .body(BodyInserters.fromValue(GenerateRiScRequestBody(initialRiSc, defaultRiScTypes)))
             .retrieve()
             .awaitBodyOrNull<String>() ?: throw SopsConfigGenerateFetchException(
             "Failed to generate default RiSc",

--- a/src/main/kotlin/no/risc/initRiSc/model/GenerateRiScRequestBody.kt
+++ b/src/main/kotlin/no/risc/initRiSc/model/GenerateRiScRequestBody.kt
@@ -1,8 +1,10 @@
 package no.risc.initRiSc.model
 
 import kotlinx.serialization.Serializable
+import no.risc.risc.models.DefaultRiScType
 
 @Serializable
 data class GenerateRiScRequestBody(
     val initialRiSc: String,
+    val defaultRiScTypes: List<DefaultRiScType>,
 )

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -9,6 +9,7 @@ import no.risc.risc.models.CreateRiScResultDTO
 import no.risc.risc.models.DeleteRiScResultDTO
 import no.risc.risc.models.DifferenceDTO
 import no.risc.risc.models.DifferenceRequestBody
+import no.risc.risc.models.NewRiScRequestBody
 import no.risc.risc.models.PublishRiScResultDTO
 import no.risc.risc.models.RiScContentResultDTO
 import no.risc.risc.models.RiScResult
@@ -81,7 +82,7 @@ class RiScController(
         @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String,
         @PathVariable repositoryOwner: String,
         @PathVariable repositoryName: String,
-        @RequestBody riSc: RiScWrapperObject,
+        @RequestBody newRiSc: NewRiScRequestBody,
         @RequestParam generateDefault: Boolean = false,
     ): CreateRiScResultDTO {
         val createRiscResultDTO =
@@ -93,7 +94,7 @@ class RiScController(
                         gcpAccessToken = GCPAccessToken(gcpAccessToken),
                         githubAccessToken = GithubAccessToken(gitHubAccessToken),
                     ),
-                content = riSc,
+                content = newRiSc.toRiScWrapperObject(),
                 defaultBranch =
                     githubConnector
                         .fetchRepositoryInfo(
@@ -102,6 +103,7 @@ class RiScController(
                             gitHubAccessToken = gitHubAccessToken,
                         ).defaultBranch,
                 generateDefault = generateDefault,
+                defaultRiScTypes = newRiSc.defaultRiScTypes,
             )
         if (createRiscResultDTO.riScContent != null) {
             riScService.uploadRiScToRosa(createRiscResultDTO.riScId, repositoryName, createRiscResultDTO.riScContent)

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -22,6 +22,7 @@ import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.initRiSc.InitRiScServiceIntegration
 import no.risc.risc.models.ContentStatus
 import no.risc.risc.models.CreateRiScResultDTO
+import no.risc.risc.models.DefaultRiScType
 import no.risc.risc.models.DeleteRiScResultDTO
 import no.risc.risc.models.DifferenceDTO
 import no.risc.risc.models.DifferenceStatus
@@ -363,7 +364,8 @@ class RiScService(
      * @param content The new content of the RiSc, including the SOPS config.
      * @param accessTokens The access tokens to use for authentication.
      * @param defaultBranch The name of the default branch of the repository.
-     * @param generateDefault Indicates if the content of the RiSc should be based on the default RiSc.
+     * @param generateDefault Indicates if the content of the RiSc should be based on default RiSc types.
+     * @param defaultRiScTypes Types of default RiScs to generate the RiSc from in cases where generateDefault is true
      * @throws CreatingRiScException If the creation fails.
      */
     suspend fun createRiSc(
@@ -373,6 +375,7 @@ class RiScService(
         accessTokens: AccessTokens,
         defaultBranch: String,
         generateDefault: Boolean,
+        defaultRiScTypes: List<DefaultRiScType>,
     ): CreateRiScResultDTO {
         val uniqueRiScId = generateRiScId(filenamePrefix)
         LOGGER.info("Generating default content")
@@ -380,7 +383,7 @@ class RiScService(
             content.copy(
                 riSc =
                     if (generateDefault) {
-                        initRiScService.generateDefaultRiSc(content.riSc)
+                        initRiScService.generateDefaultRiSc(content.riSc, defaultRiScTypes)
                     } else {
                         content.riSc
                     },

--- a/src/main/kotlin/no/risc/risc/models/NewRiScRequestBody.kt
+++ b/src/main/kotlin/no/risc/risc/models/NewRiScRequestBody.kt
@@ -15,7 +15,7 @@ data class NewRiScRequestBody(
     val schemaVersion: String,
     val userInfo: UserInfo,
     val sopsConfig: SopsConfig,
-    val defaultRiScTypes: List<DefaultRiScType>,
+    val defaultRiScTypes: List<DefaultRiScType> = listOf(DefaultRiScType.Standard),
 ) {
     fun toRiScWrapperObject(): RiScWrapperObject =
         RiScWrapperObject(

--- a/src/main/kotlin/no/risc/risc/models/NewRiScRequestBody.kt
+++ b/src/main/kotlin/no/risc/risc/models/NewRiScRequestBody.kt
@@ -1,0 +1,28 @@
+package no.risc.risc.models
+
+import kotlinx.serialization.Serializable
+
+enum class DefaultRiScType {
+    Ops,
+    InternalJob,
+    Standard,
+}
+
+@Serializable
+data class NewRiScRequestBody(
+    val riSc: String,
+    val isRequiresNewApproval: Boolean,
+    val schemaVersion: String,
+    val userInfo: UserInfo,
+    val sopsConfig: SopsConfig,
+    val defaultRiScTypes: List<DefaultRiScType>,
+) {
+    fun toRiScWrapperObject(): RiScWrapperObject =
+        RiScWrapperObject(
+            riSc,
+            isRequiresNewApproval,
+            schemaVersion,
+            userInfo,
+            sopsConfig,
+        )
+}

--- a/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
+++ b/src/test/kotlin/no/risc/initRiSc/InitRiScServiceIntegrationTests.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.risc.exception.exceptions.SopsConfigGenerateFetchException
 import no.risc.infra.connector.InitRiScServiceConnector
+import no.risc.risc.models.DefaultRiScType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,7 +32,7 @@ class InitRiScServiceIntegrationTests {
 
         assertThrows<SopsConfigGenerateFetchException> {
             runBlocking {
-                initRiScServiceIntegration.generateDefaultRiSc("")
+                initRiScServiceIntegration.generateDefaultRiSc("", listOf(DefaultRiScType.Standard))
             }
         }
     }
@@ -53,7 +54,10 @@ class InitRiScServiceIntegrationTests {
 
         val response =
             runBlocking {
-                initRiScServiceIntegration.generateDefaultRiSc("""{ "title": "title", "scope": "scope"}""")
+                initRiScServiceIntegration.generateDefaultRiSc(
+                    """{ "title": "title", "scope": "scope"}""",
+                    listOf(DefaultRiScType.Standard),
+                )
             }
 
         assertEquals(


### PR DESCRIPTION
## initialize-risc-api changes
* Modified endpoint for generating default RiSc to allow choosing between different types of initial RiScs
* Adjusted existing tests to new functionality
* Added tests for the new functionality

Checkout: https://github.com/kartverket/initialize-risc-api/pull/176

## backend changes
* Modified endpoint for creating RiSc to allow choosing between different types of initial RiScs
* Adjusted existing tests to new functionality