### PR TITLE
Added functionality for fetching data about default riscs from Airtable

### DIFF
--- a/src/main/kotlin/no/risc/initRiSc/InitRiScController.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScController.kt
@@ -1,0 +1,15 @@
+package no.risc.initRiSc
+
+import no.risc.initRiSc.model.RiScTypeDescriptor
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/initrisc")
+class InitRiScController(
+    private val initRiScServiceIntegration: InitRiScServiceIntegration,
+) {
+    @GetMapping
+    suspend fun getAllDefaultRiScTypeDescriptors(): List<RiScTypeDescriptor> = initRiScServiceIntegration.fetchDefaultRiScTypeDescriptors()
+}

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceIntegration.kt
@@ -1,8 +1,10 @@
 package no.risc.initRiSc
 
+import no.risc.exception.exceptions.FetchException
 import no.risc.exception.exceptions.SopsConfigGenerateFetchException
 import no.risc.infra.connector.InitRiScServiceConnector
 import no.risc.initRiSc.model.GenerateRiScRequestBody
+import no.risc.initRiSc.model.RiScTypeDescriptor
 import no.risc.risc.models.DefaultRiScType
 import no.risc.risc.models.ProcessRiScResultDTO
 import no.risc.risc.models.ProcessingStatus
@@ -42,4 +44,18 @@ class InitRiScServiceIntegration(
                 statusMessage = ProcessingStatus.ErrorWhenCreatingRiSc.message,
             ),
         )
+
+    suspend fun fetchDefaultRiScTypeDescriptors(): List<RiScTypeDescriptor> {
+        val descriptors =
+            initRiScServiceConnector.webClient
+                .get()
+                .uri("/descriptors")
+                .retrieve()
+                .awaitBodyOrNull<List<RiScTypeDescriptor>>()
+
+        if (descriptors == null) {
+            throw FetchException("Failed to fetch initial riScs from Airtable", ProcessingStatus.FailedToFetchFromAirtable)
+        }
+        return descriptors
+    }
 }

--- a/src/main/kotlin/no/risc/initRiSc/model/RiScTypeDescriptor.kt
+++ b/src/main/kotlin/no/risc/initRiSc/model/RiScTypeDescriptor.kt
@@ -1,0 +1,15 @@
+package no.risc.initRiSc.model
+
+import kotlinx.serialization.Serializable
+import no.risc.risc.models.DefaultRiScType
+
+@Serializable
+data class RiScTypeDescriptor(
+    val riScType: DefaultRiScType,
+    val listName: String,
+    val listDescription: String,
+    val defaultTitle: String,
+    val defaultScope: String,
+    val numberOfScenarios: Int?,
+    val numberOfActions: Int?,
+)

--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -172,6 +172,7 @@ enum class ProcessingStatus(
     FailedToFetchGCPOAuth2TokenInformation("Failed to fetch GCP OAuth2 token information"),
     FailedToFetchGCPIAMPermissions("Failed to fetch GCP IAM permissions for crypto key"),
     FailedToCreateSops("Failed to create SOPS configuration"),
+    FailedToFetchFromAirtable("Failed to fetch from airtable"),
 }
 
 @Serializable


### PR DESCRIPTION
# Fetching data about default RiScs from Airtable
This data is automatically fetched from airtable:
<img width="220" height="170" alt="image" src="https://github.com/user-attachments/assets/444baf56-da5b-4da9-86bd-73c0c369c311" />

# Changed flow of create risc form
Instead of defining title and scope before the type of default RiSc, the type of default RiSc is defined first.
<img width="527" height="79" alt="image" src="https://github.com/user-attachments/assets/9113796c-8549-4b7e-bb57-c219c03bd0d1" />


# Auto-fill title and scope based on selected default RiSc
When selecting a default RiSc type, the title and scope is auto-filled according to airtable. In the example below, the initial RiSc "Build and Deploy" was selected.
<img width="665" height="623" alt="image" src="https://github.com/user-attachments/assets/4ad8c9af-cc0b-441e-a97f-56e6e90aee1c" />

