### PR TITLE
refactor: update RISC files to follow new naming convention

### DIFF
--- a/MANUAL_RISC_CREATION.md
+++ b/MANUAL_RISC_CREATION.md
@@ -2,11 +2,9 @@
 
 This guide explains how to manually create RiSc (Risk Scorecard) files in GitHub without using the UI.
 
-> 🚀 **Want a quick reference?** See [QUICK_REFERENCE.md](docs/QUICK_REFERENCE.md) for a one-page summary.
-
 ## Overview
 
-While the recommended way to create RiSc files is through the Backstage UI, you can also create them manually by directly adding files to your GitHub repository. However, you **must follow specific naming conventions** for the system to recognize your RiSc files.
+While the recommended way to create RiSc files is through the Risc scorecard plugin in kartverket.dev, you can also create them manually by directly adding files to your GitHub repository. However, you **must follow specific naming conventions** for the system to recognize your RiSc files.
 
 ## Naming Convention Requirements
 
@@ -26,8 +24,7 @@ risc-abc12
 Where:
 - `<prefix>` is configured in your environment (typically `risc`)
 - `<identifier>` is a unique 5-character alphanumeric string (e.g., `abc12`, `xyz99`, `a1b2c`)
-
-> 💡 **Note:** The prefix is used for optimization. While the system can technically work with any branch name, using the standard prefix significantly improves performance by reducing GitHub API calls.
+- `<identifier>` can also be a suited name for your risc scorecard.
 
 ### 2. File Path
 
@@ -89,18 +86,8 @@ touch .security/riscs/risc-abc12.risc.yaml
 
 ### 4. Add RiSc Content
 
-Edit the file and add your RiSc content following the JSON schema. Here's a minimal example:
-
-```yaml
-schemaVersion: "5.0"
-title: "My Risk Analysis"
-description: "Description of the risk analysis"
-objectType: "system"
-participants:
-  riskOwner: "owner@example.com"
-  responsibleManager: "manager@example.com"
-# ... additional required fields based on schema version
-```
+Edit the file and add your RiSc content. If you want your RiSc content to contain the same scenarios and actions as an existing RiSc,
+you can copy the content from the existing file.
 
 ### 5. Commit and Push
 
@@ -117,7 +104,7 @@ git push origin risc-abc12
 
 ### 6. Verify in Backstage
 
-The RiSc should now appear in the Backstage UI as a draft. You can:
+The RiSc should now appear in the Risc scorecard plugin. You can:
 - View and edit it through the UI
 - Create a pull request to publish it
 - Continue editing manually if needed
@@ -152,11 +139,11 @@ riscs/risc-abc12.risc.yaml              ❌ WRONG (missing .security/)
 ### ❌ Missing Prefix in Branch Name
 
 ```
-Branch: abc12                           ⚠️ WORKS but not recommended
-File:   .security/riscs/abc12.risc.yaml ⚠️ WORKS but not recommended
+Branch: abc12                           ❌ WRONG (missing prefix)
+File:   .security/riscs/abc12.risc.yaml ❌ WORKS (missing prefix)
 ```
 
-While technically possible, omitting the prefix causes performance issues. Always use the prefix.
+Always use the prefix.
 
 ## Configuration Reference
 
@@ -168,13 +155,11 @@ The naming convention is controlled by environment variables:
 | `FILENAME_POSTFIX` | `risc` | Postfix before the .yaml extension |
 | `RISC_FOLDER_PATH` | `.security/riscs` | Folder where RiSc files are stored |
 
-If your deployment uses different values, adjust the examples accordingly.
-
 ## Troubleshooting
 
 ### RiSc Not Showing in UI
 
-If your manually created RiSc doesn't appear in Backstage:
+If your manually created RiSc doesn't appear in the RoS UI:
 
 1. **Check branch name format**: Ensure it follows `<prefix>-<identifier>` (e.g., `risc-abc12`)
 2. **Verify file path**: Must be `<folder>/<branch-name>.<postfix>.yaml`
@@ -182,28 +167,7 @@ If your manually created RiSc doesn't appear in Backstage:
 4. **Wait for sync**: The system may take a moment to detect the new branch
 5. **Check logs**: Review backend logs for any errors
 
-### Schema Validation Errors
-
-If the RiSc is detected but shows validation errors:
-
-1. Ensure `schemaVersion` field is present and valid (e.g., `"5.0"`)
-2. Verify all required fields are included
-3. Check field types match the schema (strings, numbers, arrays, etc.)
-4. Refer to the schema documentation for your version
-
 ## Need Help?
 
 - Check the [main README](README.md) for more information
-- Review [schema changelog](docs/schemaChangelog.md) for schema version details
-- Contact your team's Backstage administrator
-
-## Recommended Approach
-
-**For best results, use the Backstage UI** to create RiSc files. Manual creation should only be used when:
-- You need to batch-create multiple RiSc files
-- You're migrating existing risk analyses
-- You're automating RiSc creation through scripts
-- The UI is temporarily unavailable
-
-The UI handles all naming conventions automatically and provides helpful validation feedback.
-
+- Contact the RoS team.

--- a/MANUAL_RISC_CREATION.md
+++ b/MANUAL_RISC_CREATION.md
@@ -22,7 +22,6 @@ risc-abc12
 ```
 
 Where:
-- `<prefix>` is configured in your environment (typically `risc`)
 - `<identifier>` is a unique 5-character alphanumeric string (e.g., `abc12`, `xyz99`, `a1b2c`)
 - `<identifier>` can also be a suited name for your risc scorecard.
 
@@ -41,7 +40,6 @@ Place your RiSc YAML file in the following location:
 
 Where:
 - `<risc-folder>` is configured in your environment (typically `.security/riscs/`)
-- `<branch-name>` must match your branch name exactly (e.g., `risc-abc12`)
 - `<postfix>` is configured in your environment (typically `risc`)
 
 ### 3. Complete Example
@@ -51,16 +49,15 @@ For a RiSc with identifier `abc12`:
 | Component | Value |
 |-----------|-------|
 | Branch name | `risc-abc12` |
-| File path | `.security/riscs/risc-abc12.risc.yaml` |
+| File path | `.security/riscs/abc12.risc.yaml` |
 | Full GitHub path | `https://github.com/owner/repo/blob/risc-abc12/.security/riscs/risc-abc12.risc.yaml` |
 
 ## Step-by-Step Instructions
 
 ### 1. Generate a Unique Identifier
 
-Create a unique 5-character alphanumeric identifier:
 - Use a combination of letters (a-z, A-Z) and numbers (0-9)
-- Examples: `abc12`, `x7y9z`, `k3m4n`
+- Examples: `abc12`, `x7y9z`, `default`, `custom1`
 - Ensure it's not already in use in your repository
 
 ### 2. Create the Branch
@@ -81,25 +78,25 @@ Create the file at the correct path:
 mkdir -p .security/riscs
 
 # Create the RiSc file (replace abc12 with your identifier)
-touch .security/riscs/risc-abc12.risc.yaml
+touch .security/riscs/abc12.risc.yaml
 ```
 
 ### 4. Add RiSc Content
 
 Edit the file and add your RiSc content. If you want your RiSc content to contain the same scenarios and actions as an existing RiSc,
-you can copy the content from the existing file.
+you can copy the content from an existing risc file.
 
 ### 5. Commit and Push
 
 ```bash
 # Add the file
-git add .security/riscs/risc-abc12.risc.yaml
+git add .security/riscs/abc12.risc.yaml
 
 # Commit with a descriptive message
-git commit -m "Add new RiSc: risc-abc12"
+git commit -m "Add new RiSc file with ID: abc12"
 
 # Push to GitHub
-git push origin risc-abc12
+git push
 ```
 
 ### 6. Verify in Backstage
@@ -111,21 +108,13 @@ The RiSc should now appear in the Risc scorecard plugin. You can:
 
 ## Common Mistakes to Avoid
 
-### ❌ Branch and File Names Don't Match
-
-```
-Branch: risc-abc12
-File:   .security/riscs/risc-xyz99.risc.yaml  ❌ WRONG
-```
-
-The file name (without path and extension) must match the branch name exactly.
-
 ### ❌ Missing or Wrong File Extension
 
 ```
 .security/riscs/risc-abc12.yaml        ❌ WRONG (missing .risc)
 .security/riscs/risc-abc12.risc.yml    ❌ WRONG (should be .yaml not .yml)
 .security/riscs/risc-abc12.risc.yaml   ✅ CORRECT
+.security/riscs/abc123.risc.yaml       ✅ CORRECT 
 ```
 
 ### ❌ Wrong Folder Path
@@ -133,25 +122,24 @@ The file name (without path and extension) must match the branch name exactly.
 ```
 riscs/risc-abc12.risc.yaml              ❌ WRONG (missing .security/)
 .security/risc-abc12.risc.yaml          ❌ WRONG (missing riscs/ folder)
-.security/riscs/risc-abc12.risc.yaml    ✅ CORRECT
+.security/riscs/<filename>.risc.yaml    ✅ CORRECT
 ```
 
 ### ❌ Missing Prefix in Branch Name
 
 ```
 Branch: abc12                           ❌ WRONG (missing prefix)
-File:   .security/riscs/abc12.risc.yaml ❌ WORKS (missing prefix)
+Branch: risc-abc12                      ✅ CORRECT
 ```
 
-Always use the prefix.
+Always use the prefix for branch name.
 
 ## Configuration Reference
 
 The naming convention is controlled by environment variables:
 
 | Variable | Default Value | Description |
-|----------|--------------|-------------|
-| `FILENAME_PREFIX` | `risc` | Prefix for branch names and file names |
+|-------|------------|-------------|
 | `FILENAME_POSTFIX` | `risc` | Postfix before the .yaml extension |
 | `RISC_FOLDER_PATH` | `.security/riscs` | Folder where RiSc files are stored |
 

--- a/MANUAL_RISC_CREATION.md
+++ b/MANUAL_RISC_CREATION.md
@@ -1,0 +1,209 @@
+# Manual RiSc Creation Guide
+
+This guide explains how to manually create RiSc (Risk Scorecard) files in GitHub without using the UI.
+
+> 🚀 **Want a quick reference?** See [QUICK_REFERENCE.md](docs/QUICK_REFERENCE.md) for a one-page summary.
+
+## Overview
+
+While the recommended way to create RiSc files is through the Backstage UI, you can also create them manually by directly adding files to your GitHub repository. However, you **must follow specific naming conventions** for the system to recognize your RiSc files.
+
+## Naming Convention Requirements
+
+### 1. Branch Name
+
+Create a branch with the following naming pattern:
+
+```
+<prefix>-<identifier>
+```
+
+**Example:**
+```
+risc-abc12
+```
+
+Where:
+- `<prefix>` is configured in your environment (typically `risc`)
+- `<identifier>` is a unique 5-character alphanumeric string (e.g., `abc12`, `xyz99`, `a1b2c`)
+
+> 💡 **Note:** The prefix is used for optimization. While the system can technically work with any branch name, using the standard prefix significantly improves performance by reducing GitHub API calls.
+
+### 2. File Path
+
+Place your RiSc YAML file in the following location:
+
+```
+<risc-folder>/<branch-name>.<postfix>.yaml
+```
+
+**Example:**
+```
+.security/riscs/risc-abc12.risc.yaml
+```
+
+Where:
+- `<risc-folder>` is configured in your environment (typically `.security/riscs/`)
+- `<branch-name>` must match your branch name exactly (e.g., `risc-abc12`)
+- `<postfix>` is configured in your environment (typically `risc`)
+
+### 3. Complete Example
+
+For a RiSc with identifier `abc12`:
+
+| Component | Value |
+|-----------|-------|
+| Branch name | `risc-abc12` |
+| File path | `.security/riscs/risc-abc12.risc.yaml` |
+| Full GitHub path | `https://github.com/owner/repo/blob/risc-abc12/.security/riscs/risc-abc12.risc.yaml` |
+
+## Step-by-Step Instructions
+
+### 1. Generate a Unique Identifier
+
+Create a unique 5-character alphanumeric identifier:
+- Use a combination of letters (a-z, A-Z) and numbers (0-9)
+- Examples: `abc12`, `x7y9z`, `k3m4n`
+- Ensure it's not already in use in your repository
+
+### 2. Create the Branch
+
+```bash
+# From your repository root, create and checkout a new branch
+git checkout -b risc-abc12
+```
+
+Replace `abc12` with your chosen identifier.
+
+### 3. Create the RiSc File
+
+Create the file at the correct path:
+
+```bash
+# Create directory if it doesn't exist
+mkdir -p .security/riscs
+
+# Create the RiSc file (replace abc12 with your identifier)
+touch .security/riscs/risc-abc12.risc.yaml
+```
+
+### 4. Add RiSc Content
+
+Edit the file and add your RiSc content following the JSON schema. Here's a minimal example:
+
+```yaml
+schemaVersion: "5.0"
+title: "My Risk Analysis"
+description: "Description of the risk analysis"
+objectType: "system"
+participants:
+  riskOwner: "owner@example.com"
+  responsibleManager: "manager@example.com"
+# ... additional required fields based on schema version
+```
+
+### 5. Commit and Push
+
+```bash
+# Add the file
+git add .security/riscs/risc-abc12.risc.yaml
+
+# Commit with a descriptive message
+git commit -m "Add new RiSc: risc-abc12"
+
+# Push to GitHub
+git push origin risc-abc12
+```
+
+### 6. Verify in Backstage
+
+The RiSc should now appear in the Backstage UI as a draft. You can:
+- View and edit it through the UI
+- Create a pull request to publish it
+- Continue editing manually if needed
+
+## Common Mistakes to Avoid
+
+### ❌ Branch and File Names Don't Match
+
+```
+Branch: risc-abc12
+File:   .security/riscs/risc-xyz99.risc.yaml  ❌ WRONG
+```
+
+The file name (without path and extension) must match the branch name exactly.
+
+### ❌ Missing or Wrong File Extension
+
+```
+.security/riscs/risc-abc12.yaml        ❌ WRONG (missing .risc)
+.security/riscs/risc-abc12.risc.yml    ❌ WRONG (should be .yaml not .yml)
+.security/riscs/risc-abc12.risc.yaml   ✅ CORRECT
+```
+
+### ❌ Wrong Folder Path
+
+```
+riscs/risc-abc12.risc.yaml              ❌ WRONG (missing .security/)
+.security/risc-abc12.risc.yaml          ❌ WRONG (missing riscs/ folder)
+.security/riscs/risc-abc12.risc.yaml    ✅ CORRECT
+```
+
+### ❌ Missing Prefix in Branch Name
+
+```
+Branch: abc12                           ⚠️ WORKS but not recommended
+File:   .security/riscs/abc12.risc.yaml ⚠️ WORKS but not recommended
+```
+
+While technically possible, omitting the prefix causes performance issues. Always use the prefix.
+
+## Configuration Reference
+
+The naming convention is controlled by environment variables:
+
+| Variable | Default Value | Description |
+|----------|--------------|-------------|
+| `FILENAME_PREFIX` | `risc` | Prefix for branch names and file names |
+| `FILENAME_POSTFIX` | `risc` | Postfix before the .yaml extension |
+| `RISC_FOLDER_PATH` | `.security/riscs` | Folder where RiSc files are stored |
+
+If your deployment uses different values, adjust the examples accordingly.
+
+## Troubleshooting
+
+### RiSc Not Showing in UI
+
+If your manually created RiSc doesn't appear in Backstage:
+
+1. **Check branch name format**: Ensure it follows `<prefix>-<identifier>` (e.g., `risc-abc12`)
+2. **Verify file path**: Must be `<folder>/<branch-name>.<postfix>.yaml`
+3. **Confirm file exists on branch**: Check that the file exists on the correct branch in GitHub
+4. **Wait for sync**: The system may take a moment to detect the new branch
+5. **Check logs**: Review backend logs for any errors
+
+### Schema Validation Errors
+
+If the RiSc is detected but shows validation errors:
+
+1. Ensure `schemaVersion` field is present and valid (e.g., `"5.0"`)
+2. Verify all required fields are included
+3. Check field types match the schema (strings, numbers, arrays, etc.)
+4. Refer to the schema documentation for your version
+
+## Need Help?
+
+- Check the [main README](README.md) for more information
+- Review [schema changelog](docs/schemaChangelog.md) for schema version details
+- Contact your team's Backstage administrator
+
+## Recommended Approach
+
+**For best results, use the Backstage UI** to create RiSc files. Manual creation should only be used when:
+- You need to batch-create multiple RiSc files
+- You're migrating existing risk analyses
+- You're automating RiSc creation through scripts
+- The UI is temporarily unavailable
+
+The UI handles all naming conventions automatically and provides helpful validation feedback.
+

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ For local development the **ISSUER_URI** can be set to "http://localhost:7007/ap
 Because RoS-as-Code is based on using Github for storage, we need to set som rules on how things are to be named.
 This is to be able to determine the states of the RiSc analyses and to be able to detect the changes that are being made.
 
+> 📖 **Creating RiSc files manually?** See the detailed guide: [Manual RiSc Creation Guide](MANUAL_RISC_CREATION.md)
+
 <br>
 
 ## RiSc file names

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -970,7 +970,6 @@ class GithubConnector(
         accessToken: String,
         riScId: String,
         branch: String,
-
     ): OffsetDateTime? {
         // Try with prefixed path first
         val prefixedResult =

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -50,7 +50,6 @@ import org.springframework.web.reactive.function.client.awaitBodyOrNull
 import org.springframework.web.reactive.function.client.toEntity
 import reactor.core.publisher.Mono
 import java.time.OffsetDateTime
-import kotlin.compareTo
 
 @Component
 class GithubConnector(

--- a/src/main/kotlin/no/risc/github/GithubHelper.kt
+++ b/src/main/kotlin/no/risc/github/GithubHelper.kt
@@ -278,9 +278,31 @@ class GithubHelper(
         return if (queryParts.isEmpty()) base else "$base?${queryParts.joinToString("&")}"
     }
 
+    /**
+     * Normalizes a RiSc ID by removing the filename prefix if present.
+     *
+     * @param riScId The RiSc ID (may or may not include the prefix)
+     * @return The normalized RiSc ID without prefix
+     */
+    fun normalizeId(riScId: String): String = riScId.removePrefix(if (filenamePrefix.isBlank()) "" else "$filenamePrefix-")
+
+    /**
+     * Generates a branch name from a normalized RiSc ID by adding the prefix.
+     *
+     * @param normalizedId The normalized RiSc ID (without prefix)
+     * @return The branch name (with prefix if configured)
+     */
+    fun toBranchName(normalizedId: String): String = if (filenamePrefix.isBlank()) normalizedId else "$filenamePrefix-$normalizedId"
+
+    /**
+     * Normalizes a RiSc ID by removing the filename prefix, and generates the corresponding branch name.
+     *
+     * @param riScId The RiSc ID (may or may not include the prefix)
+     * @return Pair of (normalizedId, branchName)
+     */
     fun normalizeAndBranch(riScId: String): Pair<String, String> {
-        val normalized = riScId.removePrefix(if (filenamePrefix.isBlank()) "" else "$filenamePrefix-")
-        val branchName = if (filenamePrefix.isBlank()) normalized else "$filenamePrefix-$normalized"
+        val normalized = normalizeId(riScId)
+        val branchName = toBranchName(normalized)
         return normalized to branchName
     }
 }

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -3,6 +3,7 @@ package no.risc.risc
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.risc.github.GitHubAppService
 import no.risc.github.GithubConnector
+import no.risc.github.GithubHelper
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.infra.connector.models.GithubAccessToken
@@ -38,6 +39,7 @@ class RiScController(
     private val githubConnector: GithubConnector,
     private val gitHubAppService: GitHubAppService,
     private val slackService: SlackService,
+    private val githubHelper: GithubHelper,
     @Value("\${filename.prefix}") private val filenamePrefix: String,
 ) {
     @GetMapping("/{repositoryOwner}/{repositoryName}/all")
@@ -112,12 +114,7 @@ class RiScController(
         if (createRiscResultDTO.riScContent != null) {
             riScService.uploadRiScToRosa(createRiscResultDTO.riScId, repositoryName, createRiscResultDTO.riScContent)
         }
-        val normalizedId =
-            createRiscResultDTO
-                .riScId
-                .removePrefix(
-                    if (filenamePrefix.isBlank()) "" else "$filenamePrefix-",
-                )
+        val (normalizedId, _) = githubHelper.normalizeAndBranch(createRiscResultDTO.riScId)
         return createRiscResultDTO.copy(riScId = normalizedId)
     }
 

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -17,6 +17,7 @@ import no.risc.risc.models.RiScResult
 import no.risc.risc.models.RiScWrapperObject
 import no.risc.risc.models.UserInfo
 import no.risc.slack.SlackService
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,6 +38,7 @@ class RiScController(
     private val githubConnector: GithubConnector,
     private val gitHubAppService: GitHubAppService,
     private val slackService: SlackService,
+    @Value("\${filename.prefix}") private val filenamePrefix: String,
 ) {
     @GetMapping("/{repositoryOwner}/{repositoryName}/all")
     suspend fun getAllRiScsDefault(
@@ -110,7 +112,13 @@ class RiScController(
         if (createRiscResultDTO.riScContent != null) {
             riScService.uploadRiScToRosa(createRiscResultDTO.riScId, repositoryName, createRiscResultDTO.riScContent)
         }
-        return createRiscResultDTO
+        val normalizedId =
+            createRiscResultDTO
+                .riScId
+                .removePrefix(
+                    if (filenamePrefix.isBlank()) "" else "$filenamePrefix-",
+                )
+        return createRiscResultDTO.copy(riScId = normalizedId)
     }
 
     @PutMapping("/{repositoryOwner}/{repositoryName}/{id}", produces = ["application/json"])


### PR DESCRIPTION
# Prosess for PR

Alle PR'er skal først sees på og godkjennes av en i RoS-teamet. Deretter, bruk "Request Review" og assign en fra team SKVIS for å signalisere at PR'en er ferdig med intern review. Beskriv så under hva du mener SKVIS'er skal gjøre.

## Hei SKIVS'er :wave:

<!-- Fjern alternativene som ikke er relevant -->

:test_tube: teste lokalt?

## 📝 Beskrivelse

[Notion](https://www.notion.so/bekks/Oppdatere-navne-konvensjon-for-hva-risc-filer-kan-hete-2c56bd30854180eda3b1c2aa2037d259?source=copy_link)

Denne PR-en introduserer robust støtte for manuell opprettelse av RiSc-filer med fleksible navnekonvensjoner, samtidig som den opprettholder bakoverkompatibilitet med eldre navnemønstre. 
Inkluderer dokumentasjon, normaliseringslogikk og forbedret feilhåndtering for manuelt opprettede risikokortfiler.

Det er nå mulig å opprette en RiSc fil manuelt uten prefix. I brukergrensesnittet vil nye ROSer bli opprettet uten prefix.

---

## ✅ Sjekkliste

### Generelt

- [x] Branchen er rebaset på `main` eller main er merget inn.
- [x] [Test-sjekklisten](#test-sjekkliste) er gjennomført hensiktsmessig.

### Test-sjekkliste
- Introduserte endringer funker som forventet.
- Sjekk at man kan hoppe mellom RoS'er
- Sjekk at RoS kan opprettes
  - Initiell RoS
  - Kan velge kryptonøkkel
- Sjekk at RoS kan oppdateres, både i table og drawer (trykk refresh på et tiltak f.eks).
- Sjekk eventuelle nye/endrede UI-elementer i både dark- og lightmode.
- Verifiser endringer med designer(e) eller minst ett annet teammedlem hvis teamet er uten designer

---
