### PR TITLE
make less git calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ val bouncyCastleVersion = "1.82"
 val mockkVersion = "1.14.6"
 val junitVersion = "6.0.2"
 val springdocVersion = "2.8.4"
+val caffeineVersion = "3.1.8"
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
@@ -72,6 +73,8 @@ dependencies {
     }
 
     implementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
+
+    implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
 
     testImplementation(platform("org.junit:junit-bom:$junitVersion")) {
         because("The BOM (bill of materials) provides correct versions for all JUnit libraries used.")

--- a/src/main/kotlin/no/risc/config/CacheConfig.kt
+++ b/src/main/kotlin/no/risc/config/CacheConfig.kt
@@ -1,0 +1,23 @@
+package no.risc.config
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import no.risc.github.RiScMainAndBranchContentWithLastPublishedInfo
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class CacheConfig {
+    @Bean
+    fun encryptedRiScContentCache(
+        @Value("\${cache.risc.ttl-minutes:5}") ttlMinutes: Long,
+        @Value("\${cache.risc.max-size:500}") maxSize: Long,
+    ): Cache<String, RiScMainAndBranchContentWithLastPublishedInfo> =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(ttlMinutes, TimeUnit.MINUTES)
+            .maximumSize(maxSize)
+            .build()
+}

--- a/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
+++ b/src/main/kotlin/no/risc/github/GithubRiscMetadata.kt
@@ -16,6 +16,11 @@ data class RiScMainAndBranchContent(
     val branchContent: GithubContentResponse,
 )
 
+data class RiScMainAndBranchContentWithLastPublishedInfo(
+    val contents: RiScMainAndBranchContent,
+    val lastPublished: no.risc.risc.models.LastPublished? = null,
+)
+
 fun chooseRiScContentFromStatus(
     status: RiScStatus,
     branchRiScContent: GithubContentResponse,

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -56,6 +56,27 @@ class RiScController(
             latestSupportedVersion = "5.2",
         )
 
+    @GetMapping("/{repositoryOwner}/{repositoryName}/{latestSupportedVersion}/{riScId}")
+    suspend fun getRiSc(
+        @RequestHeader("GCP-Access-Token") gcpAccessToken: String,
+        @RequestHeader("GitHub-Access-Token") gitHubAccessToken: String? = null,
+        @PathVariable repositoryOwner: String,
+        @PathVariable repositoryName: String,
+        @PathVariable latestSupportedVersion: String,
+        @PathVariable riScId: String,
+    ): RiScContentResultDTO =
+        riScService.fetchRisc(
+            riScId = riScId,
+            owner = repositoryOwner,
+            repository = repositoryName,
+            accessTokens =
+                AccessTokens(
+                    gcpAccessToken = GCPAccessToken(gcpAccessToken),
+                    githubAccessToken = gitHubAppService.getGitHubAccessToken(gitHubAccessToken),
+                ),
+            latestSupportedVersion = latestSupportedVersion,
+        )
+
     @GetMapping("/{repositoryOwner}/{repositoryName}/{latestSupportedVersion}/all")
     suspend fun getAllRiScs(
         @RequestHeader("GCP-Access-Token") gcpAccessToken: String,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,16 @@ googleService.additionalAllowedGCPProjectIds =${ADDITIONAL_ALLOWED_GCP_PROJECT_I
 
 slack.feedback.webhook.url=${SLACK_FEEDBACK_WEBHOOK_URL}
 
+# Cache Configuration
+# TTL (time-to-live) in minutes for RiSc cache entries
+cache.risc.ttl-minutes=${CACHE_RISC_TTL_MINUTES:5}
+# Maximum number of entries in the RiSc cache
+cache.risc.max-size=${CACHE_RISC_MAX_SIZE:500}
+
+# Async Request Timeout
+# Timeout for asynchronous request handling (in milliseconds)
+spring.mvc.async.request-timeout=60000
+
 # OpenAPI / Swagger UI Configuration
 # Disabled by default for production, enabled via the ENABLE_API_DOCS environment variable
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
- **Refactor mapping of RiScdata from github to separate method**
- **Introducing Caffaine (in memory) caching for risc fetching**
- **Extend maximum request timeout to 60s**
- **Endpoint for fetching single risc**

# 📝 Beskrivelse

[Oppgave i Notion](https://www.notion.so/bekks/Arbeidsbrett-1ac6bd3085418023b447d1520b4e211d?p=2fb6bd30854180c6bf5af525c586d9c5&pm=s)

<!-- Beskriv kort hva som er endret og gjerne legg ved link til Notion oppgave Pro-tip: marker teksten over og lim inn lenken til oppgavekortet 😉. -->
<!-- PS: Legg gjerne lenken til PR'en i Notion kortet også :) -->

_Etter en kort beskrivelse av oppgaven skal det her være beskrevet hvordan PR'en er testet lokalt med tilhørende relevant dokumentasjon (skjermbilder, linker til Dev-miljø, osv.). Se [test-sjekklisten i front-end repo](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) for hvordan testing skal gjøres. Om endringene lar seg teste i isolasjon via API'et, kan du selvsagt gjøre det, men en sanity-sjekk front-end er uansett å anbefale_

Se [front-end PR](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/pull/881) for testing

<!-- Legg til skjermbilder eller GIF-er som viser endringene visuelt. -->
<!-- Eventuelt linker til relevante ting (risc.yaml-fil, spesielle RoS'er i dev-miljøet) -->

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
