### PR TITLE
Local sandbox

### DIFF
--- a/.run/✨Local Server.run.xml
+++ b/.run/✨Local Server.run.xml
@@ -6,7 +6,7 @@
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/.env" />
     </option>
-    <module name="backstage-plugin-risk-scorecard-backend.main" />
+    <module name="backstage-plugin-risk-scorecard-backend" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="no.risc.RiScApplicationKt" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Or download a specific version manually. See https://github.com/getsops/sops/rel
 ### Start the app from intelliJ
 To run the application, simply open the repository locally and select `✨Local Server` as your run configuration, then run it.
 
+#### Local Sandbox Mode
+For a fully mocked development environment, you can run the application with the `local-sandboxed` profile. This disables authentication, mocks GitHub storage using the local filesystem, and mocks encryption services.
+Run it using:
+```shell
+./gradlew bootRunLocal
+```
+<br>
+
+
 
 ### Linting and formatting
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,3 +103,11 @@ tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
         "-Dio.netty.tryReflectionSetAccessible=true",
     )
 }
+
+tasks.register<org.springframework.boot.gradle.tasks.run.BootRun>("bootRunLocal") {
+    dependsOn("testClasses")
+    group = "application"
+    description = "Run with local-sandboxed profile (includes test classpath for local mocks)"
+    classpath = sourceSets["main"].runtimeClasspath + sourceSets["test"].runtimeClasspath
+    mainClass.set("no.risc.RiScApplicationKt")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,4 +110,5 @@ tasks.register<org.springframework.boot.gradle.tasks.run.BootRun>("bootRunLocal"
     description = "Run with local-sandboxed profile (includes test classpath for local mocks)"
     classpath = sourceSets["main"].runtimeClasspath + sourceSets["test"].runtimeClasspath
     mainClass.set("no.risc.RiScApplicationKt")
+    systemProperty("spring.profiles.active", "local-sandboxed")
 }

--- a/src/main/kotlin/no/risc/crypto/sops/SopsCryptoService.kt
+++ b/src/main/kotlin/no/risc/crypto/sops/SopsCryptoService.kt
@@ -8,6 +8,7 @@ import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.infra.connector.models.GCPAccessToken
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.File
@@ -15,6 +16,7 @@ import java.io.InputStreamReader
 import kotlin.collections.set
 
 @Service
+@Profile("!(local-crypto | local-sandboxed)")
 class SopsCryptoService(
     private val props: SopsCryptoProperties,
 ) : CryptoServicePort {

--- a/src/main/kotlin/no/risc/crypto/sops/SopsCryptoService.kt
+++ b/src/main/kotlin/no/risc/crypto/sops/SopsCryptoService.kt
@@ -2,6 +2,7 @@ package no.risc.crypto.sops
 
 import no.risc.crypto.sops.model.RiScWithConfig
 import no.risc.crypto.sops.model.SopsConfig
+import no.risc.encryption.CryptoServicePort
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.SopsEncryptionException
 import no.risc.infra.connector.models.GCPAccessToken
@@ -16,7 +17,7 @@ import kotlin.collections.set
 @Service
 class SopsCryptoService(
     private val props: SopsCryptoProperties,
-) {
+) : CryptoServicePort {
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(SopsCryptoService::class.java)
 
@@ -54,7 +55,7 @@ class SopsCryptoService(
         return cleanConfig
     }
 
-    fun decryptWithSopsConfig(
+    override fun decryptWithSopsConfig(
         ciphertext: String,
         gcpAccessToken: GCPAccessToken,
     ): RiScWithConfig {
@@ -139,7 +140,7 @@ class SopsCryptoService(
             }
     }
 
-    fun encrypt(
+    override fun encrypt(
         text: String,
         config: SopsConfig,
         gcpAccessToken: GCPAccessToken,

--- a/src/main/kotlin/no/risc/encryption/CryptoServicePort.kt
+++ b/src/main/kotlin/no/risc/encryption/CryptoServicePort.kt
@@ -1,0 +1,19 @@
+package no.risc.encryption
+
+import no.risc.crypto.sops.model.RiScWithConfig
+import no.risc.crypto.sops.model.SopsConfig
+import no.risc.infra.connector.models.GCPAccessToken
+
+interface CryptoServicePort {
+    fun encrypt(
+        text: String,
+        config: SopsConfig,
+        gcpAccessToken: GCPAccessToken,
+        riScId: String,
+    ): String
+
+    fun decryptWithSopsConfig(
+        ciphertext: String,
+        gcpAccessToken: GCPAccessToken,
+    ): RiScWithConfig
+}

--- a/src/main/kotlin/no/risc/github/GitHubAppService.kt
+++ b/src/main/kotlin/no/risc/github/GitHubAppService.kt
@@ -55,15 +55,16 @@ class GitHubAppService(
     }
 
     fun getGitHubAccessToken(tokenFromHeader: String?): GithubAccessToken =
-        tokenFromHeader?.let { GithubAccessToken(it) }
-            ?: if (environment.activeProfiles.contains("local")) {
+        when {
+            tokenFromHeader != null -> GithubAccessToken(tokenFromHeader)
+            environment.activeProfiles.contains("local-sandboxed") -> GithubAccessToken("local-dummy")
+            environment.activeProfiles.contains("local") ->
                 throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "A GitHub personal access token MUST be provided when running locally.",
                 )
-            } else {
-                getInstallationToken()
-            }
+            else -> getInstallationToken()
+        }
 
     private fun fetchGitHubInstallationToken(): GitHubAccessTokenResponse =
         RestClient

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -58,7 +58,8 @@ class GithubConnector(
     @Value("\${filename.postfix}") private val filenamePostfix: String,
     @Value("\${filename.prefix}") private val filenamePrefix: String,
     private val githubHelper: GithubHelper,
-) : WebClientConnector("https://api.github.com/repos") {
+) : WebClientConnector("https://api.github.com/repos"),
+    GithubConnectorPort {
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(GithubConnector::class.java)
     }
@@ -104,7 +105,7 @@ class GithubConnector(
      * @param repository The repository to fetch RiSc identifiers from.
      * @param githubAccessToken The GitHub access token to use for authorization.
      */
-    suspend fun fetchRiScGithubMetadata(
+    override suspend fun fetchRiScGithubMetadata(
         owner: String,
         repository: String,
         githubAccessToken: GithubAccessToken,
@@ -153,7 +154,7 @@ class GithubConnector(
      * @param repository The repository to fetch RiSc identifiers from.
      * @param githubAccessToken The GitHub access token to use for authorization.
      */
-    suspend fun fetchBranchAndMainRiScContent(
+    override suspend fun fetchBranchAndMainRiScContent(
         riScId: String,
         owner: String,
         repository: String,
@@ -190,7 +191,7 @@ class GithubConnector(
      * @param id The ID of the RiSC.
      * @param accessToken The GitHub access token to use for authorization.
      */
-    suspend fun fetchPublishedRiSc(
+    override suspend fun fetchPublishedRiSc(
         owner: String,
         repository: String,
         id: String,
@@ -380,7 +381,7 @@ class GithubConnector(
      * @param accessToken The GitHub access token to use for authorization.
      * @param riScId The ID of the RiSc to gather information for.
      */
-    internal suspend fun fetchLastPublishedRiScDateAndCommitNumber(
+    override suspend fun fetchLastPublishedRiScDateAndCommitNumber(
         owner: String,
         repository: String,
         accessToken: String,
@@ -420,7 +421,7 @@ class GithubConnector(
      * @param gitHubAccessToken The GitHub access token to make the changes with.
      * @param userInfo Information on the user responsible for the update/creation.
      */
-    internal suspend fun updateOrCreateDraft(
+    override suspend fun updateOrCreateDraft(
         owner: String,
         repository: String,
         riScId: String,
@@ -827,7 +828,7 @@ class GithubConnector(
      * @param userInfo Information about the user that is creating the pull request, i.e., the user who has approved the changes.
      * @throws CreatePullRequestException If creation of the pull request failed.
      */
-    suspend fun createPullRequestForRiSc(
+    override suspend fun createPullRequestForRiSc(
         owner: String,
         repository: String,
         riScId: String,
@@ -919,7 +920,7 @@ class GithubConnector(
      * @param riScId The ID of the RiSc to delete.
      * @throws DeletingRiScException On all errors
      */
-    suspend fun deleteRiSc(
+    override suspend fun deleteRiSc(
         owner: String,
         repository: String,
         accessToken: String,
@@ -1252,7 +1253,7 @@ class GithubConnector(
      * @param gitHubAccessToken The GitHub access token to use for fetching the information
      * @throws PermissionDeniedOnGitHubException when the GitHub access token used does not have read access to the repository.
      */
-    suspend fun fetchRepositoryInfo(
+    override suspend fun fetchRepositoryInfo(
         gitHubAccessToken: String,
         repositoryOwner: String,
         repositoryName: String,

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -40,6 +40,7 @@ import no.risc.utils.tryWithErrorLogging
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient.RequestBodySpec
@@ -54,6 +55,7 @@ import reactor.core.publisher.Mono
 import java.time.OffsetDateTime
 
 @Component
+@Profile("!(local-github | local-sandboxed)")
 class GithubConnector(
     @Value("\${filename.postfix}") private val filenamePostfix: String,
     @Value("\${filename.prefix}") private val filenamePrefix: String,

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -1283,10 +1283,10 @@ class GithubConnector(
         )
     }
 
-    suspend fun fetchInitRiScDescriptorConfigs(gitHubAccessToken: GithubAccessToken): GithubContentResponse =
+    override suspend fun fetchInitRiScDescriptorConfigs(gitHubAccessToken: GithubAccessToken): GithubContentResponse =
         fetchRiScContent(githubHelper.uriToInitRiscConfig(), gitHubAccessToken.value)
 
-    suspend fun fetchInitRiSc(
+    override suspend fun fetchInitRiSc(
         initRiScId: String,
         accessToken: String,
     ): GithubContentResponse =

--- a/src/main/kotlin/no/risc/github/GithubConnectorPort.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnectorPort.kt
@@ -1,0 +1,72 @@
+package no.risc.github
+
+import no.risc.github.models.GithubContentResponse
+import no.risc.github.models.GithubPullRequestObject
+import no.risc.github.models.RiScApprovalPRStatus
+import no.risc.infra.connector.models.GithubAccessToken
+import no.risc.infra.connector.models.RepositoryInfo
+import no.risc.risc.models.DeleteRiScResultDTO
+import no.risc.risc.models.LastPublished
+import no.risc.risc.models.UserInfo
+
+interface GithubConnectorPort {
+    suspend fun fetchRiScGithubMetadata(
+        owner: String,
+        repository: String,
+        githubAccessToken: GithubAccessToken,
+    ): List<RiScGithubMetadata>
+
+    suspend fun fetchBranchAndMainRiScContent(
+        riScId: String,
+        owner: String,
+        repository: String,
+        githubAccessToken: GithubAccessToken,
+    ): RiScMainAndBranchContent
+
+    suspend fun fetchPublishedRiSc(
+        owner: String,
+        repository: String,
+        id: String,
+        accessToken: String,
+    ): GithubContentResponse
+
+    suspend fun fetchLastPublishedRiScDateAndCommitNumber(
+        owner: String,
+        repository: String,
+        accessToken: String,
+        riScId: String,
+    ): LastPublished?
+
+    suspend fun updateOrCreateDraft(
+        owner: String,
+        repository: String,
+        riScId: String,
+        defaultBranch: String,
+        fileContent: String,
+        requiresNewApproval: Boolean,
+        gitHubAccessToken: GithubAccessToken,
+        userInfo: UserInfo,
+    ): RiScApprovalPRStatus
+
+    suspend fun deleteRiSc(
+        owner: String,
+        repository: String,
+        accessToken: String,
+        riScId: String,
+    ): DeleteRiScResultDTO
+
+    suspend fun createPullRequestForRiSc(
+        owner: String,
+        repository: String,
+        riScId: String,
+        requiresNewApproval: Boolean,
+        gitHubAccessToken: String,
+        userInfo: UserInfo,
+    ): GithubPullRequestObject
+
+    suspend fun fetchRepositoryInfo(
+        gitHubAccessToken: String,
+        repositoryOwner: String,
+        repositoryName: String,
+    ): RepositoryInfo
+}

--- a/src/main/kotlin/no/risc/github/GithubConnectorPort.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnectorPort.kt
@@ -69,4 +69,11 @@ interface GithubConnectorPort {
         repositoryOwner: String,
         repositoryName: String,
     ): RepositoryInfo
+
+    suspend fun fetchInitRiSc(
+        initRiScId: String,
+        accessToken: String,
+    ): GithubContentResponse
+
+    suspend fun fetchInitRiScDescriptorConfigs(gitHubAccessToken: GithubAccessToken): GithubContentResponse
 }

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScService.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScService.kt
@@ -1,0 +1,29 @@
+package no.risc.initRiSc
+
+import no.risc.infra.connector.models.AccessTokens
+import no.risc.initRiSc.model.RiScTypeDescriptor
+
+interface InitRiScService {
+    /**
+     * Returns an initial RiSc of some ID. Use the getInitRiScDescriptors method to return a list of valid IDs.
+     *
+     * @param initRiScId ID of initial RiSc.
+     *
+     * @param initialContent A JSON serialized RiSc to base the initial RiSc on. initialContent must include the
+     *                    `title` and `scope` fields. These are the only fields used from initialContent.
+     *
+     * @param accessTokens Access tokens (GitHub and GCP).
+     */
+    suspend fun getInitRiSc(
+        initRiScId: String,
+        initialContent: String,
+        accessTokens: AccessTokens,
+    ): String
+
+    /**
+     * Gets a list of RiSc descriptors. Each RiSc descriptor describes an available initial RiSc with properties
+     * including ID, name/description displayed in the ui (listName/listDescription), the total number of scenarios, and
+     * the total number of actions.
+     */
+    suspend fun getInitRiScDescriptors(accessTokens: AccessTokens): List<RiScTypeDescriptor>
+}

--- a/src/main/kotlin/no/risc/initRiSc/InitRiScServiceGitHubImpl.kt
+++ b/src/main/kotlin/no/risc/initRiSc/InitRiScServiceGitHubImpl.kt
@@ -3,7 +3,7 @@ package no.risc.initRiSc
 import kotlinx.serialization.json.Json
 import no.risc.exception.exceptions.FetchException
 import no.risc.exception.exceptions.RiScNotValidOnFetchException
-import no.risc.github.GithubConnector
+import no.risc.github.GithubConnectorPort
 import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.initRiSc.model.InitRiScDescriptorConfig
@@ -16,9 +16,9 @@ import org.springframework.stereotype.Service
 
 @Service
 class InitRiScServiceGitHubImpl(
-    private val githubConnector: GithubConnector,
-) {
-    suspend fun getInitRiScDescriptors(accessTokens: AccessTokens): List<RiScTypeDescriptor> {
+    private val githubConnector: GithubConnectorPort,
+) : InitRiScService {
+    override suspend fun getInitRiScDescriptors(accessTokens: AccessTokens): List<RiScTypeDescriptor> {
         val initRiScDescriptorConfigs = getInitRiScDescriptorConfigs(accessTokens)
         return initRiScDescriptorConfigs
             .map {
@@ -45,7 +45,7 @@ class InitRiScServiceGitHubImpl(
      *
      * @param initRiScId ID of default RiSc to generate the RiSc from.
      */
-    suspend fun getInitRiSc(
+    override suspend fun getInitRiSc(
         initRiScId: String,
         initialContent: String,
         accessTokens: AccessTokens,

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -3,7 +3,7 @@ package no.risc.risc
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.risc.config.AppConstants
 import no.risc.github.GitHubAppService
-import no.risc.github.GithubConnector
+import no.risc.github.GithubConnectorPort
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
 import no.risc.infra.connector.models.GithubAccessToken
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "risc", description = "Risk Scorecard management endpoints")
 class RiScController(
     private val riScService: RiScService,
-    private val githubConnector: GithubConnector,
+    private val githubConnector: GithubConnectorPort,
     private val gitHubAppService: GitHubAppService,
     private val slackService: SlackService,
 ) {

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -55,7 +55,7 @@ class RiScService(
     private val githubConnector: GithubConnectorPort,
     @Value("\${filename.prefix}") val filenamePrefix: String,
     private val cryptoService: CryptoServicePort,
-    private val initRiScService: InitRiScServiceIntegration,
+    private val initRiScService: InitRiScService,
 ) {
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(RiScService::class.java)

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -4,15 +4,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import no.risc.crypto.sops.SopsCryptoService
 import no.risc.crypto.sops.model.SopsConfig
+import no.risc.encryption.CryptoServicePort
 import no.risc.exception.exceptions.CreatingRiScException
 import no.risc.exception.exceptions.DifferenceException
 import no.risc.exception.exceptions.RiScConflictException
 import no.risc.exception.exceptions.RiScNotValidOnUpdateException
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.UpdatingRiScException
-import no.risc.github.GithubConnector
+import no.risc.github.GithubConnectorPort
 import no.risc.github.RiScGithubMetadata
 import no.risc.github.chooseRiScContentFromStatus
 import no.risc.github.getRiScStatus
@@ -52,10 +52,10 @@ import org.springframework.stereotype.Service
 
 @Service
 class RiScService(
-    private val githubConnector: GithubConnector,
+    private val githubConnector: GithubConnectorPort,
     @Value("\${filename.prefix}") val filenamePrefix: String,
-    private val sopsCryptoService: SopsCryptoService,
-    private val initRiScService: InitRiScServiceGitHubImpl,
+    private val cryptoService: CryptoServicePort,
+    private val initRiScService: InitRiScServiceIntegration,
 ) {
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(RiScService::class.java)
@@ -316,7 +316,7 @@ class RiScService(
     ): RiScContentResultDTO =
         if (status == GithubStatus.Success) {
             try {
-                val decryptedContent = sopsCryptoService.decryptWithSopsConfig(ciphertext = data(), gcpAccessToken = gcpAccessToken)
+                val decryptedContent = cryptoService.decryptWithSopsConfig(ciphertext = data(), gcpAccessToken = gcpAccessToken)
                 RiScContentResultDTO(
                     riScId = riScId,
                     status = ContentStatus.Success,
@@ -500,7 +500,7 @@ class RiScService(
         }
 
         val encryptedData: String =
-            sopsCryptoService.encrypt(
+            cryptoService.encrypt(
                 text = content.riSc,
                 config = sopsConfig,
                 gcpAccessToken = accessTokens.gcpAccessToken,

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -21,7 +21,7 @@ import no.risc.github.models.GithubPullRequestObject
 import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
-import no.risc.initRiSc.InitRiScServiceGitHubImpl
+import no.risc.initRiSc.InitRiScService
 import no.risc.risc.models.ContentStatus
 import no.risc.risc.models.CreateRiScResultDTO
 import no.risc.risc.models.DeleteRiScResultDTO

--- a/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
+++ b/src/main/kotlin/no/risc/security/AccessTokenValidationFilter.kt
@@ -8,11 +8,13 @@ import kotlinx.coroutines.runBlocking
 import no.risc.exception.exceptions.InvalidAccessTokensException
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.utils.Repository
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 @WebFilter(urlPatterns = ["/api/**"])
+@Profile("!(local-sandboxed)")
 class AccessTokenValidationFilter(
     private val validationService: ValidationService,
 ) : OncePerRequestFilter() {

--- a/src/main/kotlin/no/risc/security/SecurityConfig.kt
+++ b/src/main/kotlin/no/risc/security/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.env.Environment
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -23,6 +24,7 @@ import java.lang.Thread.sleep
 
 @Configuration
 @EnableWebSecurity
+@Profile("!(local-sandboxed)")
 class SecurityConfig(
     private val environment: Environment,
 ) {

--- a/src/main/kotlin/no/risc/security/ValidationService.kt
+++ b/src/main/kotlin/no/risc/security/ValidationService.kt
@@ -3,7 +3,7 @@ package no.risc.security
 import no.risc.exception.exceptions.AccessTokenValidationFailedException
 import no.risc.exception.exceptions.InvalidAccessTokensException
 import no.risc.exception.exceptions.RepositoryAccessException
-import no.risc.github.GithubConnector
+import no.risc.github.GithubConnectorPort
 import no.risc.google.GoogleServiceIntegration
 import no.risc.infra.connector.models.GitHubPermission
 import no.risc.risc.models.ProcessingStatus
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class ValidationService(
-    private val githubConnector: GithubConnector,
+    private val githubConnector: GithubConnectorPort,
     private val googleServiceIntegration: GoogleServiceIntegration,
 ) {
     suspend fun validateAccessTokens(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,8 @@
 # This file is automatically read by the kotlin application.
+# For local development without GitHub: add spring.profiles.active=local-github
+# For local development without crypto service: add spring.profiles.active=local-crypto
+# For local development without either: add spring.profiles.active=local-sandboxed
+# in application-local.properties (and use dummy values for other required props).
 # Key-values in `application-local.properties` will override entries in this file.
 # Colon (:) syntax may be used to set default values if the preceding value is empty.
 # Example: `someProp=${MISSING_ENV:defaultValue}

--- a/src/test/kotlin/no/risc/encryption/LocalCryptoService.kt
+++ b/src/test/kotlin/no/risc/encryption/LocalCryptoService.kt
@@ -1,0 +1,34 @@
+package no.risc.encryption
+
+import no.risc.crypto.sops.model.RiScWithConfig
+import no.risc.crypto.sops.model.SopsConfig
+import no.risc.infra.connector.models.GCPAccessToken
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * No-op crypto service for local development without a running crypto service.
+ * Files are stored and returned as plain (unencrypted) text.
+ * Activated by the `local-crypto` or `local-sandboxed` Spring profile.
+ */
+@Component
+@Profile("local-crypto | local-sandboxed")
+class LocalCryptoService : CryptoServicePort {
+    /** Encryption is a no-op: plain text is returned unchanged. */
+    override fun encrypt(
+        text: String,
+        config: SopsConfig,
+        gcpAccessToken: GCPAccessToken,
+        riScId: String,
+    ): String = text
+
+    /** Decryption is a no-op: the content is treated as already plain text. */
+    override fun decryptWithSopsConfig(
+        ciphertext: String,
+        gcpAccessToken: GCPAccessToken,
+    ): RiScWithConfig =
+        RiScWithConfig(
+            riSc = ciphertext,
+            sopsConfig = SopsConfig(shamir_threshold = 0, gcp_kms = emptyList()),
+        )
+}

--- a/src/test/kotlin/no/risc/github/LocalGithubConnector.kt
+++ b/src/test/kotlin/no/risc/github/LocalGithubConnector.kt
@@ -1,0 +1,326 @@
+package no.risc.github
+
+import no.risc.github.models.GithubContentResponse
+import no.risc.github.models.GithubPullRequestBranch
+import no.risc.github.models.GithubPullRequestObject
+import no.risc.github.models.GithubStatus
+import no.risc.github.models.RiScApprovalPRStatus
+import no.risc.infra.connector.models.GitHubPermission
+import no.risc.infra.connector.models.GithubAccessToken
+import no.risc.infra.connector.models.RepositoryInfo
+import no.risc.risc.models.DeleteRiScResultDTO
+import no.risc.risc.models.LastPublished
+import no.risc.risc.models.ProcessingStatus
+import no.risc.risc.models.UserInfo
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.OffsetDateTime
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+/**
+ * Local filesystem-based implementation of [GithubConnectorPort] for development without GitHub access.
+ *
+ * Activated by the `local-github` Spring profile. Files are stored under [storagePath]:
+ * ```
+ * <storagePath>/
+ *   <repository>/
+ *     branch/
+ *       default/                     ← published RiScs
+ *         <stem>.<postfix>.yaml
+ *       <riScId>/                    ← draft branch (directory presence = branch exists)
+ *         <stem>.<postfix>.yaml
+ *     pr/
+ *       <riScId>/                    ← open PR (directory presence = PR exists)
+ * ```
+ */
+@Component
+@Profile("local-github | local-sandboxed")
+class LocalGithubConnector(
+    @Value("\${filename.prefix}") private val branchPrefix: String,
+    @Value("\${filename.postfix}") private val filenamePostfix: String,
+    @Value("\${github.repository.risc-folder-path}") private val riScFolderPath: String,
+    @Value("\${github.local.storage-path:./local-github}") private val storagePath: String,
+) : GithubConnectorPort {
+    private val storageRoot: Path = Path.of(storagePath).toAbsolutePath().normalize()
+
+    /**
+     * Validates that [value] is a safe single path segment: non-blank, no path separators,
+     * no parent-directory references, and only characters valid in GitHub repository names and
+     * RiSc IDs. Throws [IllegalArgumentException] on any violation.
+     *
+     * This is the primary guard against path-traversal: tainted input is rejected here,
+     * before it is passed to any [Path] API.
+     */
+    private fun requireSafePathSegment(
+        value: String,
+        name: String,
+    ): String {
+        require(value.isNotBlank()) { "$name must not be blank" }
+        require(!value.contains('/') && !value.contains('\\')) {
+            "$name must not contain path separators"
+        }
+        require(value != "." && value != "..") { "$name must not be '.' or '..'" }
+        require(value.matches(Regex("^[A-Za-z0-9._-]+$"))) {
+            "$name contains characters not allowed in a path segment"
+        }
+        return value
+    }
+
+    /** Secondary guard: normalises [this] path and throws if it escapes [storageRoot]. */
+    private fun Path.requireUnderStorageRoot(): Path {
+        val normalised = toAbsolutePath().normalize()
+        require(normalised.startsWith(storageRoot)) { "Path traversal detected" }
+        return normalised
+    }
+
+    private fun repoDir(repository: String): Path =
+        storageRoot
+            .resolve(requireSafePathSegment(repository, "repository"))
+            .requireUnderStorageRoot()
+
+    private fun branchDir(
+        repository: String,
+        branch: String,
+    ): Path =
+        repoDir(repository)
+            .resolve("branch")
+            .resolve(requireSafePathSegment(branch, "branch"))
+            .requireUnderStorageRoot()
+
+    private fun defaultBranchDir(repository: String): Path = branchDir(repository, "default")
+
+    private fun prDir(
+        repository: String,
+        riScId: String,
+    ): Path =
+        repoDir(repository)
+            .resolve("pr")
+            .resolve(requireSafePathSegment(riScId, "riScId"))
+            .requireUnderStorageRoot()
+
+    /**
+     * Derives the filename from riScId, mirroring [no.risc.github.GithubHelper.riscPath] logic.
+     * For IDs with the form `<prefix>-<stem>-backstage_<...>`, the prefix is stripped so the
+     * stored filename matches what GitHub would hold.
+     */
+    private fun riscFilename(riScId: String): String {
+        val stem =
+            if (riScId.startsWith("$branchPrefix-") && riScId.contains("-backstage_")) {
+                riScId.removePrefix("$branchPrefix-")
+            } else {
+                riScId
+            }
+        return "$stem.$filenamePostfix.yaml"
+    }
+
+    /** Absolute path to the published (default-branch) file for [riScId]. */
+    private fun publishedFilePath(
+        repository: String,
+        riScId: String,
+    ): Path =
+        defaultBranchDir(repository)
+            .resolve(riscFilename(riScId))
+            .requireUnderStorageRoot()
+
+    /** Absolute path to the draft file for [riScId]. */
+    private fun draftFilePath(
+        repository: String,
+        riScId: String,
+    ): Path =
+        branchDir(repository, riScId)
+            .resolve(riscFilename(riScId))
+            .requireUnderStorageRoot()
+
+    private fun readFile(path: Path): GithubContentResponse =
+        if (path.isRegularFile()) {
+            GithubContentResponse(data = path.readText(), status = GithubStatus.Success)
+        } else {
+            GithubContentResponse(data = null, status = GithubStatus.NotFound)
+        }
+
+    override suspend fun fetchRepositoryInfo(
+        gitHubAccessToken: String,
+        repositoryOwner: String,
+        repositoryName: String,
+    ): RepositoryInfo =
+        RepositoryInfo(
+            defaultBranch = "default",
+            permissions = GitHubPermission.entries.toList(),
+        )
+
+    override suspend fun fetchRiScGithubMetadata(
+        owner: String,
+        repository: String,
+        githubAccessToken: GithubAccessToken,
+    ): List<RiScGithubMetadata> {
+        val publishedDir = defaultBranchDir(repository)
+        val branchBaseDir = repoDir(repository).resolve("branch")
+        val prBaseDir = repoDir(repository).resolve("pr")
+
+        val mainIds: Set<String> =
+            if (publishedDir.isDirectory()) {
+                publishedDir
+                    .listDirectoryEntries("*.$filenamePostfix.yaml")
+                    .map { file ->
+                        val fileId = file.name.substringBefore(".$filenamePostfix")
+                        if (fileId.contains("-backstage_")) "$branchPrefix-$fileId" else fileId
+                    }.toSet()
+            } else {
+                emptySet()
+            }
+
+        val branchIds: Set<String> =
+            if (branchBaseDir.isDirectory()) {
+                branchBaseDir
+                    .listDirectoryEntries()
+                    .filter { it.isDirectory() && it.name != "default" }
+                    .map { it.name }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+
+        val prIds: Set<String> =
+            if (prBaseDir.isDirectory()) {
+                prBaseDir
+                    .listDirectoryEntries()
+                    .filter { it.isDirectory() }
+                    .map { it.name }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+
+        val allIds = mainIds + branchIds
+        return allIds.map { id ->
+            RiScGithubMetadata(
+                id = id,
+                isStoredInMain = id in mainIds,
+                hasBranch = id in branchIds,
+                hasOpenPR = id in prIds,
+                prUrl = if (id in prIds) prDir(repository, id).toUri().toString() else null,
+            )
+        }
+    }
+
+    override suspend fun fetchBranchAndMainRiScContent(
+        riScId: String,
+        owner: String,
+        repository: String,
+        githubAccessToken: GithubAccessToken,
+    ): RiScMainAndBranchContent =
+        RiScMainAndBranchContent(
+            mainContent = readFile(publishedFilePath(repository, riScId)),
+            branchContent = readFile(draftFilePath(repository, riScId)),
+        )
+
+    override suspend fun fetchPublishedRiSc(
+        owner: String,
+        repository: String,
+        id: String,
+        accessToken: String,
+    ): GithubContentResponse = readFile(publishedFilePath(repository, id))
+
+    override suspend fun fetchLastPublishedRiScDateAndCommitNumber(
+        owner: String,
+        repository: String,
+        accessToken: String,
+        riScId: String,
+    ): LastPublished? = null
+
+    override suspend fun updateOrCreateDraft(
+        owner: String,
+        repository: String,
+        riScId: String,
+        defaultBranch: String,
+        fileContent: String,
+        requiresNewApproval: Boolean,
+        gitHubAccessToken: GithubAccessToken,
+        userInfo: UserInfo,
+    ): RiScApprovalPRStatus {
+        val filePath = draftFilePath(repository, riScId)
+        Files.createDirectories(filePath.parent)
+        filePath.writeText(fileContent)
+
+        val prDir = prDir(repository, riScId)
+        val prExists = prDir.isDirectory()
+        val isPublished = publishedFilePath(repository, riScId).isRegularFile()
+
+        return when {
+            !requiresNewApproval && !prExists && isPublished -> {
+                Files.createDirectories(prDir)
+                RiScApprovalPRStatus(pullRequest = localPrObject(repository, riScId), hasClosedPr = false)
+            }
+            requiresNewApproval && prExists -> {
+                prDir.toFile().deleteRecursively()
+                RiScApprovalPRStatus(pullRequest = null, hasClosedPr = true)
+            }
+            else -> RiScApprovalPRStatus(pullRequest = null, hasClosedPr = false)
+        }
+    }
+
+    override suspend fun deleteRiSc(
+        owner: String,
+        repository: String,
+        accessToken: String,
+        riScId: String,
+    ): DeleteRiScResultDTO {
+        val publishedFile = publishedFilePath(repository, riScId)
+        val branchDir = branchDir(repository, riScId)
+        val draftFile = draftFilePath(repository, riScId)
+
+        return if (!publishedFile.exists()) {
+            // Never published — delete the draft branch and any open PR
+            branchDir.toFile().deleteRecursively()
+            prDir(repository, riScId).toFile().deleteRecursively()
+            DeleteRiScResultDTO(
+                riScId = riScId,
+                status = ProcessingStatus.DeletedRiSc,
+                statusMessage = "Risk scorecard was deleted - no approval required as it was never published",
+            )
+        } else {
+            // Was published — stage deletion by removing just the draft file
+            Files.createDirectories(branchDir)
+            if (draftFile.exists()) draftFile.toFile().delete()
+            DeleteRiScResultDTO(
+                riScId = riScId,
+                status = ProcessingStatus.DeletedRiScRequiresApproval,
+                statusMessage = "Risk scorecard was staged for deletion - the deletion requires approval",
+            )
+        }
+    }
+
+    override suspend fun createPullRequestForRiSc(
+        owner: String,
+        repository: String,
+        riScId: String,
+        requiresNewApproval: Boolean,
+        gitHubAccessToken: String,
+        userInfo: UserInfo,
+    ): GithubPullRequestObject {
+        Files.createDirectories(prDir(repository, riScId))
+        return localPrObject(repository, riScId)
+    }
+
+    private fun localPrObject(
+        repository: String,
+        riScId: String,
+    ): GithubPullRequestObject =
+        GithubPullRequestObject(
+            url = prDir(repository, riScId).toUri().toString(),
+            title = "Updated risk scorecard",
+            createdAt = OffsetDateTime.now(),
+            head = GithubPullRequestBranch(ref = riScId),
+            base = GithubPullRequestBranch(ref = "default"),
+            number = 0,
+        )
+}

--- a/src/test/kotlin/no/risc/github/LocalGithubConnector.kt
+++ b/src/test/kotlin/no/risc/github/LocalGithubConnector.kt
@@ -311,6 +311,14 @@ class LocalGithubConnector(
         return localPrObject(repository, riScId)
     }
 
+    override suspend fun fetchInitRiSc(
+        initRiScId: String,
+        accessToken: String,
+    ): GithubContentResponse = GithubContentResponse(status = GithubStatus.NotFound, data = null)
+
+    override suspend fun fetchInitRiScDescriptorConfigs(gitHubAccessToken: GithubAccessToken): GithubContentResponse =
+        GithubContentResponse(status = GithubStatus.NotFound, data = null)
+
     private fun localPrObject(
         repository: String,
         riScId: String,

--- a/src/test/kotlin/no/risc/security/LocalSecurityConfig.kt
+++ b/src/test/kotlin/no/risc/security/LocalSecurityConfig.kt
@@ -1,0 +1,28 @@
+package no.risc.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * Permissive security configuration for local sandboxed development.
+ * All requests are permitted without authentication or token validation.
+ * Activated by the `local-sandboxed` Spring profile.
+ */
+@Configuration
+@EnableWebSecurity
+@Profile("local-sandboxed")
+class LocalSecurityConfig {
+    @Bean
+    fun localSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .csrf { it.ignoringRequestMatchers("/api/**") }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+        return http.build()
+    }
+}

--- a/src/test/resources/application-local-crypto.properties
+++ b/src/test/resources/application-local-crypto.properties
@@ -1,0 +1,3 @@
+# local-crypto profile — only active when spring.profiles.active includes local-crypto
+# Dummy URL so CryptoServiceConfig/CryptoServiceConnector can be instantiated without CRYPTO_SERVICE_URL
+cryptoService.baseUrl=http://localhost:0

--- a/src/test/resources/application-local-github.properties
+++ b/src/test/resources/application-local-github.properties
@@ -1,0 +1,3 @@
+# Local GitHub profile — only active when spring.profiles.active=local-github
+# Path to local directory for RiSc storage (relative to working directory)
+github.local.storage-path=./local-github

--- a/src/test/resources/application-local-sandboxed.properties
+++ b/src/test/resources/application-local-sandboxed.properties
@@ -1,0 +1,25 @@
+# local-sandboxed profile — activates both local GitHub and local crypto mocks.
+# Self-contained: all required properties are provided here so the app starts
+# with spring.profiles.active=local-sandboxed alone (no other profile needed).
+
+# --- GitHub mock ---
+# Path to local directory for RiSc storage (relative to working directory)
+github.local.storage-path=./local-github
+
+# --- Crypto mock ---
+# Dummy URL so CryptoServiceConfig/CryptoServiceConnector can be instantiated
+cryptoService.baseUrl=http://localhost:0
+
+# --- Required properties (no external services needed) ---
+github.repository.risc-folder-path=.security/risc
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:7007/api/auth
+filename.prefix=risc
+filename.postfix=risc
+initRisc.baseUrl=http://localhost:0
+sops.backendPublicKey=age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf
+github.app.private-key=dummy
+github.app.installation-id=0
+github.app.id=0
+slack.feedback.webhook.url=http://localhost:0
+springdoc.swagger-ui.enabled=true
+springdoc.api-docs.enabled=true

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,0 +1,4 @@
+# Local development profile — activate with spring.profiles.active=local (e.g. via run config)
+# Pulls in local GitHub + local crypto mocks so no external services are needed.
+# Alternatively, activate local-sandboxed directly without this file.
+spring.profiles.include=local-sandboxed

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,4 +1,3 @@
-# Local development profile — activate with spring.profiles.active=local (e.g. via run config)
-# Pulls in local GitHub + local crypto mocks so no external services are needed.
-# Alternatively, activate local-sandboxed directly without this file.
-spring.profiles.include=local-sandboxed
+# Local development profile (spring.profiles.active=local)
+# Runs against real external services. A GitHub PAT must be provided via the
+# GitHub-Access-Token header. Use local-sandboxed for a fully mocked setup.

--- a/src/test/resources/risc-api-local.postman_collection.json
+++ b/src/test/resources/risc-api-local.postman_collection.json
@@ -1,0 +1,1300 @@
+{
+  "info": {
+    "name": "RiSc API – Local Sandboxed",
+    "description": "Test collection for the RiSc backend with spring.profiles.active=local-sandboxed.\nNo auth headers required. Files are stored under ./local-github/<repo>/.\n\nState transitions covered:\n  (new)                    → Draft                     [A02]\n  Draft                    → Draft                     [A04]  (UpdatedRiSc)\n  Draft                    → SentForApproval            [A05]  (CreatedPullRequest)\n  SentForApproval          → Draft                     [A07]  (UpdatedRiScRequiresNewApproval)\n  Draft                    → SentForApproval            [A09]  (CreatedPullRequest)\n  SentForApproval          → Published                 [A10]  ⚙️ simulate PR merge\n  Published                → SentForApproval            [A11]  (UpdatedRiScAndCreatedPullRequest)\n  Draft (never published)  → Deleted                   [B02]  (DeletedRiSc)\n  Published                → DeletionDraft              [C04]  (DeletedRiScRequiresApproval)\n  DeletionDraft            → DeletionSentForApproval   [C06]  (CreatedPullRequest)\n  DeletionSentForApproval  → Deleted                   [C07]  ⚙️ simulate deletion PR merge\n\nSteps marked ⚙️ MANUAL require local filesystem operations — instructions are printed to\nthe Postman console (open View → Show Postman Console) when the step is sent.\n\nNOTE: The riSc field must be JSON (not YAML).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080"
+    },
+    {
+      "key": "owner",
+      "value": "local-owner"
+    },
+    {
+      "key": "repo",
+      "value": "my-repo"
+    },
+    {
+      "key": "riScId",
+      "value": ""
+    },
+    {
+      "key": "gcpToken",
+      "value": "dummy-gcp-token"
+    }
+  ],
+  "item": [
+    {
+      "name": "A – Full lifecycle",
+      "description": "Runs a RiSc through every normal-lifecycle state:\nDraft → SentForApproval → Draft (re-approval) → SentForApproval → Published → SentForApproval\n\nRun A01–A13 in order. Step A10 requires a manual filesystem operation.",
+      "item": [
+        {
+          "name": "A01 – List (baseline)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A02 – Create → Draft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('riScId returned', () => pm.expect(res.riScId).to.be.a('string').and.not.empty);",
+                  "pm.test('status is CreatedRiSc', () => pm.expect(res.status).to.eql('CreatedRiSc'));",
+                  "if (res.riScId) { pm.collectionVariables.set('riScId', res.riScId); console.log('riScId set to', res.riScId); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Test Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A03 – List → assert Draft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc appears in list', () => pm.expect(found).to.be.ok);",
+                  "pm.test('RiSc status is Draft', () => pm.expect(found && found.riScStatus).to.eql('Draft'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A04 – Update draft → Draft (UpdatedRiSc)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is UpdatedRiSc', () => pm.expect(res.status).to.eql('UpdatedRiSc'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Updated Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test \\u2014 updated scope\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\",\\\"Insider\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\",\\\"Information leak\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}},{\\\"title\\\":\\\"Enable audit logging\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN2\\\",\\\"description\\\":\\\"Enable full audit logging for data access\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A05 – Send for approval → SentForApproval (CreatedPullRequest)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is CreatedPullRequest', () => pm.expect(res.status).to.eql('CreatedPullRequest'));",
+                  "pm.test('pendingApproval returned', () => pm.expect(res.pendingApproval).to.not.be.null);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Local Developer\",\n  \"email\": \"dev@localhost\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/publish/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "publish",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A06 – List → assert SentForApproval",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is SentForApproval', () => pm.expect(found && found.riScStatus).to.eql('SentForApproval'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A07 – Update (requiresNewApproval=true) → Draft, closes PR (UpdatedRiScRequiresNewApproval)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is UpdatedRiScRequiresNewApproval', () => pm.expect(res.status).to.eql('UpdatedRiScRequiresNewApproval'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Updated Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test \\u2014 updated scope\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\",\\\"Insider\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\",\\\"Information leak\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}},{\\\"title\\\":\\\"Enable audit logging\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN2\\\",\\\"description\\\":\\\"Enable full audit logging for data access\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\",\n  \"isRequiresNewApproval\": true,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A08 – List → assert Draft (PR was closed)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is Draft', () => pm.expect(found && found.riScStatus).to.eql('Draft'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A09 – Send for approval again → SentForApproval (CreatedPullRequest)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is CreatedPullRequest', () => pm.expect(res.status).to.eql('CreatedPullRequest'));",
+                  "pm.test('pendingApproval returned', () => pm.expect(res.pendingApproval).to.not.be.null);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Local Developer\",\n  \"email\": \"dev@localhost\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/publish/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "publish",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A10 – Get difference (draft vs published)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Updated Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test — updated scope\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\",\\\"Insider\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\",\\\"Information leak\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}},{\\\"title\\\":\\\"Enable audit logging\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN2\\\",\\\"description\\\":\\\"Enable full audit logging for data access\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}/difference",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}",
+                "difference"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A10b – ⚙️ MANUAL: Simulate PR merge → Published",
+          "description": "MANUAL STEP — before sending this request, run the following shell commands from the project root to simulate GitHub merging the PR:\n\n  REPO=my-repo  ID=<riScId from variable>\n  cp ./local-github/${REPO}/branch/${ID}/*.yaml ./local-github/${REPO}/branch/default/\n  rm -rf ./local-github/${REPO}/branch/${ID}\n  rm -rf ./local-github/${REPO}/pr/${ID}\n\nThe instructions are also printed to the Postman console when you send this step.\nSending this request (GET /all) then confirms the RiSc reached Published state.",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const id   = pm.collectionVariables.get('riScId');",
+                  "const repo = pm.collectionVariables.get('repo');",
+                  "console.log('');",
+                  "console.log('⚙️  MANUAL STEP — simulate PR merge before sending this request.');",
+                  "console.log('Run from project root:');",
+                  "console.log('  REPO=' + repo + '  ID=' + id);",
+                  "console.log('  cp ./local-github/' + repo + '/branch/' + id + '/*.yaml ./local-github/' + repo + '/branch/default/');",
+                  "console.log('  rm -rf ./local-github/' + repo + '/branch/' + id);",
+                  "console.log('  rm -rf ./local-github/' + repo + '/pr/' + id);",
+                  "console.log('');"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is Published', () => pm.expect(found && found.riScStatus).to.eql('Published'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A11 – Update published → SentForApproval, auto-PR (UpdatedRiScAndCreatedPullRequest)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is UpdatedRiScAndCreatedPullRequest', () => pm.expect(res.status).to.eql('UpdatedRiScAndCreatedPullRequest'));",
+                  "pm.test('pendingApproval returned', () => pm.expect(res.pendingApproval).to.not.be.null);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Updated Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test — updated scope\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\",\\\"Insider\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\",\\\"Information leak\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}},{\\\"title\\\":\\\"Enable audit logging\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN2\\\",\\\"description\\\":\\\"Enable full audit logging for data access\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}},{\\\"title\\\":\\\"Data breach\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN2\\\",\\\"description\\\":\\\"Sensitive data is exposed due to misconfigured storage\\\",\\\"threatActors\\\":[\\\"Organised crime\\\"],\\\"vulnerabilities\\\":[\\\"Information leak\\\"],\\\"risk\\\":{\\\"probability\\\":0.02,\\\"consequence\\\":320000},\\\"actions\\\":[{\\\"title\\\":\\\"Encrypt storage\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN3\\\",\\\"description\\\":\\\"Enable encryption at rest for all data stores\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.001,\\\"consequence\\\":16000}}}]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "A12 – List → assert SentForApproval (after auto-PR)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is SentForApproval', () => pm.expect(found && found.riScStatus).to.eql('SentForApproval'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "B – Delete never-published RiSc",
+      "description": "A RiSc that was never published is deleted immediately — no PR or approval needed.\nTransition: Draft → Deleted (DeletedRiSc)",
+      "item": [
+        {
+          "name": "B01 – Create → Draft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('riScId returned', () => pm.expect(res.riScId).to.be.a('string').and.not.empty);",
+                  "pm.test('status is CreatedRiSc', () => pm.expect(res.status).to.eql('CreatedRiSc'));",
+                  "if (res.riScId) { pm.collectionVariables.set('riScId', res.riScId); console.log('riScId set to', res.riScId); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Test Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "B02 – Delete draft → Deleted immediately (DeletedRiSc)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is DeletedRiSc', () => pm.expect(res.status).to.eql('DeletedRiSc'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "B03 – List → assert RiSc is gone",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('deleted RiSc no longer in list', () => pm.expect(found).to.be.false);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "C – Delete published RiSc",
+      "description": "A published RiSc must go through an approval flow before it is fully deleted.\nTransitions: Draft → SentForApproval → Published → DeletionDraft → DeletionSentForApproval → Deleted\n\nStep C03 requires a manual filesystem operation to simulate the first PR merge.",
+      "item": [
+        {
+          "name": "C01 – Create → Draft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('riScId returned', () => pm.expect(res.riScId).to.be.a('string').and.not.empty);",
+                  "pm.test('status is CreatedRiSc', () => pm.expect(res.status).to.eql('CreatedRiSc'));",
+                  "if (res.riScId) { pm.collectionVariables.set('riScId', res.riScId); console.log('riScId set to', res.riScId); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"Test Risk Scorecard\\\",\\\"scope\\\":\\\"Local development test\\\",\\\"scenarios\\\":[{\\\"title\\\":\\\"Unauthorized access\\\",\\\"scenario\\\":{\\\"ID\\\":\\\"SCEN1\\\",\\\"description\\\":\\\"An attacker gains unauthorized access to user data\\\",\\\"threatActors\\\":[\\\"Organised crime\\\"],\\\"vulnerabilities\\\":[\\\"Unauthorized access\\\"],\\\"risk\\\":{\\\"probability\\\":0.05,\\\"consequence\\\":160000},\\\"actions\\\":[{\\\"title\\\":\\\"Implement access controls\\\",\\\"action\\\":{\\\"ID\\\":\\\"ACTN1\\\",\\\"description\\\":\\\"Implement role-based access control\\\",\\\"status\\\":\\\"Not OK\\\"}}],\\\"remainingRisk\\\":{\\\"probability\\\":0.0025,\\\"consequence\\\":8000}}}]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C02 – Send for approval → SentForApproval",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is CreatedPullRequest', () => pm.expect(res.status).to.eql('CreatedPullRequest'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Local Developer\",\n  \"email\": \"dev@localhost\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/publish/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "publish",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C03 – ⚙️ MANUAL: Simulate PR merge → Published",
+          "description": "MANUAL STEP — before sending this request, run the following shell commands from the project root to simulate GitHub merging the PR:\n\n  REPO=my-repo  ID=<riScId from variable>\n  cp ./local-github/${REPO}/branch/${ID}/*.yaml ./local-github/${REPO}/branch/default/\n  rm -rf ./local-github/${REPO}/branch/${ID}\n  rm -rf ./local-github/${REPO}/pr/${ID}\n\nThe instructions are also printed to the Postman console when you send this step.\nSending this request (GET /all) then confirms the RiSc reached Published state.",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const id   = pm.collectionVariables.get('riScId');",
+                  "const repo = pm.collectionVariables.get('repo');",
+                  "console.log('');",
+                  "console.log('⚙️  MANUAL STEP — simulate PR merge before sending this request.');",
+                  "console.log('Run from project root:');",
+                  "console.log('  REPO=' + repo + '  ID=' + id);",
+                  "console.log('  cp ./local-github/' + repo + '/branch/' + id + '/*.yaml ./local-github/' + repo + '/branch/default/');",
+                  "console.log('  rm -rf ./local-github/' + repo + '/branch/' + id);",
+                  "console.log('  rm -rf ./local-github/' + repo + '/pr/' + id);",
+                  "console.log('');"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is Published', () => pm.expect(found && found.riScStatus).to.eql('Published'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C04 – Delete published → DeletionDraft (DeletedRiScRequiresApproval)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is DeletedRiScRequiresApproval', () => pm.expect(res.status).to.eql('DeletedRiScRequiresApproval'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C05 – List → assert DeletionDraft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is DeletionDraft', () => pm.expect(found && found.riScStatus).to.eql('DeletionDraft'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C06 – Send deletion for approval → DeletionSentForApproval (CreatedPullRequest)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const res = pm.response.json();",
+                  "pm.test('status is CreatedPullRequest', () => pm.expect(res.status).to.eql('CreatedPullRequest'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Local Developer\",\n  \"email\": \"dev@localhost\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/publish/{{riScId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "publish",
+                "{{riScId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C07 – List → assert DeletionSentForApproval",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('RiSc status is DeletionSentForApproval', () => pm.expect(found && found.riScStatus).to.eql('DeletionSentForApproval'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        },
+        {
+          "name": "C08 – ⚙️ MANUAL: Simulate deletion PR merge → Deleted",
+          "description": "MANUAL STEP — before sending this request, run the following shell commands from the project root to simulate GitHub merging the deletion PR (remove the published file, postfix is FILENAME_POSTFIX, typically 'risc'):\n\n  REPO=my-repo  ID=<riScId from variable>  POSTFIX=risc\n  rm ./local-github/${REPO}/branch/default/${ID}.${POSTFIX}.yaml\n  rm -rf ./local-github/${REPO}/branch/${ID}\n  rm -rf ./local-github/${REPO}/pr/${ID}\n\nThe instructions are also printed to the Postman console when you send this step.\nSending this request (GET /all) then confirms the RiSc is gone.",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const id   = pm.collectionVariables.get('riScId');",
+                  "const repo = pm.collectionVariables.get('repo');",
+                  "console.log('');",
+                  "console.log('⚙️  MANUAL STEP — simulate deletion PR merge before sending this request.');",
+                  "console.log('Run from project root (POSTFIX is FILENAME_POSTFIX, typically \"risc\"):');",
+                  "console.log('  REPO=' + repo + '  ID=' + id + '  POSTFIX=risc');",
+                  "console.log('  rm ./local-github/' + repo + '/branch/default/' + id + '.${POSTFIX}.yaml');",
+                  "console.log('  rm -rf ./local-github/' + repo + '/branch/' + id);",
+                  "console.log('  rm -rf ./local-github/' + repo + '/pr/' + id);",
+                  "console.log('');"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "const items = pm.response.json();",
+                  "const found = Array.isArray(items) && items.find(r => r.riScId === pm.collectionVariables.get('riScId'));",
+                  "pm.test('deleted RiSc no longer in list', () => pm.expect(found).to.be.false);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Misc",
+      "item": [
+        {
+          "name": "Misc – Send feedback",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "text/plain"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "This is test feedback from local development"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/feedback",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "feedback"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Misc – List with Backstage filter",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}/all?backstageKind=component&backstageNamespace=default&backstageName=my-service",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}",
+                "all"
+              ],
+              "query": [
+                {
+                  "key": "backstageKind",
+                  "value": "component"
+                },
+                {
+                  "key": "backstageNamespace",
+                  "value": "default"
+                },
+                {
+                  "key": "backstageName",
+                  "value": "my-service"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Misc – Create RiSc with Backstage entity (named ID)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const res = pm.response.json();",
+                  "if (res.riScId) {",
+                  "  pm.collectionVariables.set('riScId', res.riScId);",
+                  "  console.log('riScId set to', res.riScId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "GCP-Access-Token",
+                "value": "{{gcpToken}}"
+              },
+              {
+                "key": "GitHub-Access-Token",
+                "value": "{{gcpToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"riSc\": \"{\\\"schemaVersion\\\":\\\"5.2\\\",\\\"title\\\":\\\"My Service Risk Scorecard\\\",\\\"scope\\\":\\\"The my-service component\\\",\\\"scenarios\\\":[]}\",\n  \"isRequiresNewApproval\": false,\n  \"schemaVersion\": \"5.2\",\n  \"userInfo\": {\n    \"name\": \"Local Developer\",\n    \"email\": \"dev@localhost\"\n  },\n  \"sopsConfig\": {\n    \"shamir_threshold\": 1,\n    \"gcp_kms\": [],\n    \"age\": [\n      {\n        \"recipient\": \"age1ayuv56c98uukut752jpxl68tpch2yjvx5z3agk0t73h79kq3z4fstrtvqf\"\n      }\n    ]\n  },\n  \"riscName\": \"auth-flow\",\n  \"backstageKind\": \"component\",\n  \"backstageNamespace\": \"default\",\n  \"backstageName\": \"my-service\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/risc/{{owner}}/{{repo}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "risc",
+                "{{owner}}",
+                "{{repo}}"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Oppsummering

Introduserer en **lokal utviklingsmodus** som lar utviklere kjøre backenden uten eksterne tjenester (ingen GitHub App-legitimasjon, ingen kryptotjeneste, ingen gyldige JWT-tokens kreves).

### Commits

**1. Trekk ut GithubConnectorPort og CryptoServicePort-grensesnitt**

Ren refaktorering — ingen atferdsendring. Introduserer to grensesnitt slik at `RiScService`, `RiScController` og `ValidationService` avhenger av abstraksjoner fremfor konkrete klasser:
- `GithubConnectorPort` — alle GitHub-operasjoner (hent, oppdater, publiser, slett)
- `CryptoServicePort` — krypter og dekrypter

**2. Legg til lokal utviklingsmodus**

Introduserer tre Spring-profiler (aktiveres via `spring.profiles.active` i `application-local.properties`):

| Profil | GitHub | Kryptotjeneste | GitHub-autentisering |
|---|---|---|---|
| _(ingen)_ | Real | Real | GH App |
| `local-github` | Lokalt filsystem | Real | PAT |
| `local-crypto` | Real | No-op | PAT |
| `local-sandboxed` | Lokalt filsystem | No-op | Ingen |
| `local` | Lokalt filsystem | No-op | Ingen |

De lokale implementasjonene ligger i `src/test/` og er derfor **fraværende fra produksjons-JAR-en** — de kan ikke aktiveres i produksjon selv om et profilnavn ved en feil skulle bli satt.

### Hva er inkludert

- **`LocalGithubConnector`** — filsystembasert `GithubConnectorPort`. Lagrer RiSc-filer under `./local-github/<repo>/` og speiler gren/PR-strukturen som brukes på GitHub.
- **`LocalCryptoService`** — no-op `CryptoServicePort`. Innhold lagres og returneres som ren (ukryptert) tekst.
- **`LocalSecurityConfig`** — deaktiverer JWT-autentisering og tilgangstokenfilter for `local-sandboxed`.
- **Profilspesifikke egenskaper** i `src/test/resources/` — leverer dummy-URL-er og lagringsveier for hver lokal profil.
- **`bootRunLocal`** Gradle-oppgave — kjører appen med testklassestien inkludert. IntelliJ-kjørekonfigurasjonen «✨Local Server» er oppdatert til å gjøre det samme.
- **Postman-samling** (`src/test/resources/risc-api-local.postman_collection.json`) — dekker alle RiSc-tilstandsoverganger med automatiserte påstander.

### Slik kjører du lokalt

Kopier `.env.example` til `.env`, sett dummy-verdier for påkrevde egenskaper, og kjør deretter enten:
- `./gradlew bootRunLocal`
- IntelliJ: kjør konfigurasjonen «✨Local Server»

Postman-samlingen i `src/test/resources/` dokumenterer og tester hele arbeidsflyten.