### PR TITLE
Show GCP KMS key ID when decryption fails

### DIFF
--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -329,6 +329,10 @@ class RiScService(
                 )
             } catch (e: Exception) {
                 if (e is SOPSDecryptionException) {
+                    val kmsKeyResourceId =
+                        runCatching {
+                            sopsCryptoService.extractSopsConfig(data()).gcp_kms?.firstOrNull()?.resource_id
+                        }.getOrNull()
                     RiScContentResultDTO(
                         riScId = riScId,
                         status = ContentStatus.DecryptionFailed,
@@ -337,6 +341,7 @@ class RiScService(
                         statusMessage = e.errorMessage ?: e.message ?: "Decryption failed",
                         errorCode = e.errorCode,
                         errorMessage = e.errorMessage,
+                        kmsKeyResourceId = kmsKeyResourceId,
                     )
                 } else {
                     RiScContentResultDTO(

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -331,7 +331,11 @@ class RiScService(
                 if (e is SOPSDecryptionException) {
                     val kmsKeyResourceId =
                         runCatching {
-                            sopsCryptoService.extractSopsConfig(data()).gcp_kms?.firstOrNull()?.resource_id
+                            sopsCryptoService
+                                .extractSopsConfig(data())
+                                .gcp_kms
+                                ?.firstOrNull()
+                                ?.resource_id
                         }.getOrNull()
                     RiScContentResultDTO(
                         riScId = riScId,

--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -65,6 +65,7 @@ data class RiScContentResultDTO(
     val statusMessage: String? = null,
     val errorCode: String? = null,
     val errorMessage: String? = null,
+    val kmsKeyResourceId: String? = null,
     val migrationStatus: MigrationStatus =
         MigrationStatus(
             migrationChanges = false,


### PR DESCRIPTION
## Summary

- Adds `kmsKeyResourceId: String?` to `RiScContentResultDTO` so the frontend can display which GCP KMS key a RoS is encrypted with when decryption fails
- When a `SOPSDecryptionException` is caught in `responseToRiScResult()`, the SOPS metadata is read from the ciphertext (without decrypting) to extract `gcp_kms[0].resource_id`
- Uses `runCatching` so any parse failure gracefully returns `null` — no change in behaviour for old-format files or missing SOPS metadata

## Test plan

- [ ] Open a RoS you don't have KMS access to — response should now include `kmsKeyResourceId` with the full resource ID (e.g. `projects/.../cryptoKeys/...`)
- [ ] Open a RoS you DO have access to — `kmsKeyResourceId` is `null`, no regression
- [ ] File with no `gcp_kms` in SOPS metadata — `kmsKeyResourceId` is `null`, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)