### PR TITLE
Sops version bump to 3.12.2

### DIFF
--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install SOPS
         run: |
-          SOPS_VERSION="3.11.0"
+          SOPS_VERSION="3.12.2"
           curl -Lo sops "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
           chmod +x sops
           sudo mv sops /usr/local/bin/sops
@@ -144,7 +144,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
           SOPS_OUTPUT=$(docker run --rm --entrypoint sops ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }} --version)
           echo "SOPS version output: $SOPS_OUTPUT"
-          echo "$SOPS_OUTPUT" | grep -q "3.11.0"
+          echo "$SOPS_OUTPUT" | grep -q "3.12.2"
 
       - name: Set output with build values
         id: setOutput

--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           SOPS_OUTPUT=$(docker run --rm --entrypoint sops "${{ env.AR_URL }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" --version)
           echo "SOPS version output: $SOPS_OUTPUT"
-          echo "$SOPS_OUTPUT" | grep -q "3.11.0"
+          echo "$SOPS_OUTPUT" | grep -q "3.12.2"
 
       - name: Push the Docker image to Google Artifact Registry
         if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE=eclipse-temurin:25-jre-alpine
 ARG IMAGE=eclipse-temurin:25-alpine
 ARG SOPS_BUILD_IMAGE=golang:1.25.7
-ARG SOPS_VERSION_ARG=3.11.0
+ARG SOPS_VERSION_ARG=3.12.2
 
 # Make sure the logic is in sync with Dockerfile.M4
 FROM ${BUILD_IMAGE} AS build


### PR DESCRIPTION
Sops version bumped to 3.12.2 (see [here](https://www.notion.so/bekks/Oppdatere-sops-fra-3-11-0-til-nyeste-versjon-i-backend-33e6bd30854180f3909bce226109983a?source=copy_link)). Tested and works locally. 

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
