### PR TITLE
Log unhandled GitHub API errors

### DIFF
--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -1240,7 +1240,7 @@ class GithubConnector(
                     )
                 }
 
-            else -> GithubStatus.InternalError
+            else -> GithubStatus.InternalError.also { LOGGER.error("Unhandled GitHub API error: {}", e.message, e) }
         }
 
     /**


### PR DESCRIPTION
## Summary
- The `else`-branch in `mapWebClientExceptionToGithubStatus` was silently mapping unknown exceptions to `InternalError` without any logging
- This made it impossible to diagnose what actually caused GitHub fetch failures (e.g. `FailedToFetchInitRiScConfigFromGitHub`)
- Added `LOGGER.error` with message and full stack trace for all unhandled cases

## Test plan
- [ ] Trigger a GitHub fetch failure and verify the exception is now logged with full stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)