### PR TITLE
fix: added warmup for frontend in deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -58,6 +58,12 @@ jobs:
         run: |
           docker push "${{ env.AR_URL }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
+      - name: Warm up Backstage auth service
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl -s --retry 5 --retry-delay 10 --retry-all-errors -o /dev/null -w "%{http_code}" \
+            https://risc-457384642040.europe-north1.run.app/api/auth/.well-known/openid-configuration
+
       - name: Deploy to Cloud Run
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
# 📝 Beskrivelse


Lagt til et warmup steg som curler frontend for å gjøre den tilgjengelig. Løser forhåpentligvis problemet der backenden ikke når auth i tide under deploy. 

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
