### PR TITLE
Fix: bump netty version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=eclipse-temurin:25.0.3_9-jre-ubi10-minimal@sha256:fadae232b6a4ff83dec0a6a6474c27aaf2e4fea8efe9a4d7b59aae62edad8c0b
 # We use the eclipse-temurin 'minimal' image for build stage.
-ARG SOPS_BUILD_IMAGE=golang:1.26.2
+ARG SOPS_BUILD_IMAGE=golang:1.26.3
 ARG SOPS_VERSION_ARG=3.12.2
 ARG SOCAT_VERSION_ARG=tag-1.8.1.1
 # Fetch distroless images from Google's gcr.io.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ java {
 
 extra["tomcat.version"] = "11.0.22" // Vulnerability in 11.0.20
 extra["jackson-bom.version"] = "3.1.3" // Vulnerability in 3.1.0
+extra["netty.version"] = "4.2.13.Final"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion


Fikser netty sårbarheter ved å bumpe til 4.2.13.Final. 

Også bumpet sops build image for å fjerne sårbarhet .
---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
