### PR TITLE
Edit workflow to run Pharos last, and update build stage Docker image.

### DIFF
--- a/.github/workflows/pharos.yml
+++ b/.github/workflows/pharos.yml
@@ -2,13 +2,7 @@ name: Pharos
 on:
   schedule:
     - cron: '0 6 * * 1-5'
-  workflow_run:
-    workflows:
-      - "Build and deploy RiSC-plugin backend"
-      - "Build and deploy to Spire Cloud Run"
-      - "CodeQL Advanced"
-    types:
-      - completed
+  push:
     branches:
       - main
   workflow_dispatch:
@@ -16,9 +10,6 @@ on:
 jobs:
   pharos:
     name: Run Pharos on docker image
-    if: >
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read
       packages: read
@@ -26,6 +17,8 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for image to (probably) be available
+      - run: sleep 360
       - name: "Run Pharos"
         uses: kartverket/pharos@v0.6.0
         with:

--- a/.github/workflows/pharos.yml
+++ b/.github/workflows/pharos.yml
@@ -2,7 +2,13 @@ name: Pharos
 on:
   schedule:
     - cron: '0 6 * * 1-5'
-  push:
+  workflow_run:
+    workflows:
+      - "Build and deploy RiSC-plugin backend"
+      - "Build and deploy to Spire Cloud Run"
+      - "CodeQL Advanced"
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:
@@ -10,6 +16,9 @@ on:
 jobs:
   pharos:
     name: Run Pharos on docker image
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read
       packages: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/java25@sha256:b1eb8a18891104b7405f29edbb2
 
 # Build stage for Java app
 FROM ${BUILD_IMAGE} AS build
+RUN microdnf upgrade -y && microdnf clean all
 COPY . .
 
 RUN ./gradlew build -x test


### PR DESCRIPTION
# 📝 Beskrivelse

This pull request updates the GitHub Actions workflow and the Docker build process. The most important changes are grouped below:

**CI/CD Workflow Improvements:**

* The `pharos.yml` workflow is now triggered by the completion of the other workflows (`Build and deploy RiSC-plugin backend`, `Build and deploy to Spire Cloud Run`, and `CodeQL Advanced`) instead of on every push, and only runs on the `main` branch. It also includes a condition to only run if the triggering workflow completed successfully.

**Docker Build Security and Maintenance:**

* The Docker build stage now includes a step to upgrade all packages using `microdnf upgrade -y` and cleans up afterward, ensuring the build image is up-to-date with the latest security patches.

---
## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
