### PR TITLE
fix: Improve access token validation failed exception logging

### DIFF
--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -194,7 +194,11 @@ internal class GlobalExceptionHandler {
     @ExceptionHandler(AccessTokenValidationFailedException::class)
     fun handleAccessTokenValidationFailedException(ex: AccessTokenValidationFailedException): Any {
         logger.error(ex.message, ex)
-        return ex.response
+        return ProcessRiScResultDTO(
+            riScId = "",
+            status = ProcessingStatus.AccessTokensValidationFailure,
+            statusMessage = ex.message,
+        )
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/no/risc/exception/exceptions/AccessTokenValidationFailedException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/AccessTokenValidationFailedException.kt
@@ -1,14 +1,6 @@
 package no.risc.exception.exceptions
 
-import no.risc.risc.models.ProcessRiScResultDTO
-import no.risc.risc.models.ProcessingStatus
-
-data class AccessTokenValidationFailedException(
-    val response: Any =
-        ProcessRiScResultDTO(
-            riScId = "",
-            status = ProcessingStatus.AccessTokensValidationFailure,
-            statusMessage = "An error occurred when validating access token.",
-        ),
+class AccessTokenValidationFailedException(
     override val message: String,
-) : Exception()
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/src/main/kotlin/no/risc/security/ValidationService.kt
+++ b/src/main/kotlin/no/risc/security/ValidationService.kt
@@ -27,7 +27,7 @@ class ValidationService(
                     message =
                         "An error occurred when fetching repository info for " +
                             "$repositoryOwner/$repositoryName during access token validation",
-                    cause = e
+                    cause = e,
                 )
             }
         if (!repositoryInfo.hasWriteAccess) {

--- a/src/main/kotlin/no/risc/security/ValidationService.kt
+++ b/src/main/kotlin/no/risc/security/ValidationService.kt
@@ -27,6 +27,7 @@ class ValidationService(
                     message =
                         "An error occurred when fetching repository info for " +
                             "$repositoryOwner/$repositoryName during access token validation",
+                    cause = e
                 )
             }
         if (!repositoryInfo.hasWriteAccess) {


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

Det kommer en egen PR for å generelt håndtere exceptions kastet i AccessTokenValidationFilter, som ikke blir håndtert av GlobalExceptionHandler fordi filteret kjører før DispatcherServlet, som er ansvarlig for å rute exceptions til @ControllerAdvice. Denne PR-en er kun for å forbedre logging.


Når AccessTokenValidationFailedException ble kastet, ble opprinnelig cause ikke videreført. Ønsker at stack tracen til den underliggende feilen skal vises i loggen.    

Endringer                                                                    
   
  - La til cause-parameter på AccessTokenValidationFailedException slik at den 
  underliggende feilen bevares i stack tracen
  - Viderefører cause når exceptions kastes i ValidationService                
  - Oppdaterte GlobalExceptionHandler til å bygge responsen direkte i          
  handleren, siden response-feltet ble fjernet fra exceptionklassen

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
