### PR TITLE
Fix: vuln in distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SOPS_BUILD_IMAGE=golang:1.26.2
 ARG SOPS_VERSION_ARG=3.12.2
 ARG SOCAT_VERSION_ARG=tag-1.8.1.1
 # Fetch distroless images from Google's gcr.io.
-ARG DISTROLESS_IMAGE=gcr.io/distroless/java25@sha256:b1eb8a18891104b7405f29edbb2eaca9b34179707957a0e5a41b54d4a45cbdfd
+ARG DISTROLESS_IMAGE=gcr.io/distroless/java25@sha256:70036fed3c5ba28821c5fad98b613a2fb173cc52fa893b509abedaa2e82ba9c1
 
 # Build stage for Java app
 FROM ${BUILD_IMAGE} AS build


### PR DESCRIPTION
# 📝 Beskrivelse

Byttet distroless-image for å fikse sårbarhet.
Nytt image: https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/java25/sha256:70036fed3c5ba28821c5fad98b613a2fb173cc52fa893b509abedaa2e82ba9c1

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
