### PR TITLE
fix: remove microdnf upgrade command from Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/java25@sha256:70036fed3c5ba28821c5fad98b6
 
 # Build stage for Java app
 FROM ${BUILD_IMAGE} AS build
-RUN microdnf upgrade -y && microdnf clean all
+
 COPY . .
 
 RUN ./gradlew build -x test


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

<!-- Beskriv kort hva som er endret og gjerne legg ved link til Notion oppgave Pro-tip: marker teksten over og lim inn lenken til oppgavekortet 😉. -->
<!-- PS: Legg gjerne lenken til PR'en i Notion kortet også :) -->

`microdnf upgrade` eksisterer ikke på build imaget vi benytter oss av

<!-- Legg til skjermbilder eller GIF-er som viser endringene visuelt. -->
<!-- Eventuelt linker til relevante ting (risc.yaml-fil, spesielle RoS'er i dev-miljøet) -->

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
