### PR TITLE
removed references to local.env

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Backstage backend plugin for **Risk Management as Code (RiSc)**. Risk assessment
 
 **Local dev:**
 ```bash
-cp .env.example .env.local
+cp .env.example .env
 ./run-local.sh          # Runs with spring.profiles.active=local
 # OR via IntelliJ run config: "✨Local Server"
 ```

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -a
-source .env.local
+source .env
 set +a
 ./gradlew bootRun --args="--spring.profiles.active=local" 


### PR DESCRIPTION
# 📝 Beskrivelse

Changes all references of local.env to simply .env. [See Notion](https://www.notion.so/bekks/Rydde-opp-i-inkonsekvent-bruk-av-env-vs-env-local-3506bd30854180e59796d0135bb900c2?source=copy_link)
---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
