### PR TITLE
feat: Added comment property to action

### DIFF
--- a/docs/schemaChangelog.md
+++ b/docs/schemaChangelog.md
@@ -1,5 +1,8 @@
 # Schema changelog
 
+## 5.3
+- Adds optional comment field in actions
+
 ## 5.2
 - Removes the unused valuations field
 

--- a/src/main/kotlin/no/risc/config/AppConstants.kt
+++ b/src/main/kotlin/no/risc/config/AppConstants.kt
@@ -1,5 +1,5 @@
 package no.risc.config
 
 object AppConstants {
-    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.2"
+    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.3"
 }

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -49,7 +49,11 @@ sealed interface RiSc {
                         parseJSONToClass<RiSc4X>(content)
                     }
 
-                    RiScVersion.RiSc5XVersion.VERSION_5_0, RiScVersion.RiSc5XVersion.VERSION_5_1, RiScVersion.RiSc5XVersion.VERSION_5_2 -> {
+                    RiScVersion.RiSc5XVersion.VERSION_5_0,
+                    RiScVersion.RiSc5XVersion.VERSION_5_1,
+                    RiScVersion.RiSc5XVersion.VERSION_5_2,
+                    RiScVersion.RiSc5XVersion.VERSION_5_3,
+                    -> {
                         parseJSONToClass<RiSc5X>(content)
                     }
 
@@ -82,6 +86,9 @@ sealed interface RiScVersion {
 
         @SerialName("5.2")
         VERSION_5_2,
+
+        @SerialName("5.3")
+        VERSION_5_3,
         ;
 
         override fun asString(): String = serializer().descriptor.getElementName(ordinal)
@@ -181,7 +188,7 @@ data class RiSc5XScenario(
 private object RiSc5XScenarioActionSerializer : FlattenSerializer<RiSc5XScenarioAction>(
     serializer = RiSc5XScenarioAction.generatedSerializer(),
     flattenKey = "action",
-    subKeys = listOf("ID", "url", "status", "description", "lastUpdated", "lastUpdatedBy"),
+    subKeys = listOf("ID", "url", "status", "description", "lastUpdated", "lastUpdatedBy", "comment"),
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -197,6 +204,7 @@ data class RiSc5XScenarioAction(
     @Serializable(KNullableOffsetDateTimeSerializer::class)
     val lastUpdated: OffsetDateTime? = null,
     val lastUpdatedBy: String? = null,
+    val comment: String? = null,
 )
 
 /***************

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -46,6 +46,7 @@ import no.risc.utils.comparison.MigrationChangedValue
  * - 4.2 -> 5.0 (change action status values)
  * - 5.0 -> 5.1 (add lastUpdatedBy field to action)
  * - 5.1 -> 5.2 (remove valuations)
+ * - 5.2 -> 5.3 (add comment field to action)
  *
  * @param riSc The RiSc to migrate.
  * @param lastPublished The last published version of the RisC to use for migration to 4.2
@@ -137,6 +138,9 @@ fun migrate(
  * - 4.0 -> 4.1 (changed probability and consequence values to use base number 20)
  * - 4.1 -> 4.2 (add lastUpdated field to action)
  * - 4.2 -> 5.0 (change action status values)
+ * - 5.0 -> 5.1 (add lastUpdatedBy field to action)
+ * - 5.1 -> 5.2 (remove valuations)
+ * - 5.2 -> 5.3 (add comment field to action)
  *
  * @param riSc The RiSc to migrate
  * @param migrationStatus The migration status so far
@@ -176,6 +180,9 @@ private fun handleMigrate(
 
             riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_1 ->
                 migrateFrom51To52(riSc, migrationStatus)
+
+            riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_2 ->
+                migrateFrom52To53(riSc, migrationStatus)
 
             else -> {
                 if (riSc.schemaVersion != null) {
@@ -682,3 +689,17 @@ fun migrateFrom51To52(
         ),
     )
 }
+
+/**
+ * Migrate RiSc with changes from 5.2 to 5.3
+ *
+ * Adds optional comment field to actions (defaults to null, no data transformation needed).
+ */
+fun migrateFrom52To53(
+    riSc: RiSc5X,
+    migrationStatus: MigrationStatus,
+): Pair<RiSc5X, MigrationStatus> =
+    Pair(
+        riSc.copy(schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_3),
+        migrationStatus,
+    )

--- a/src/main/kotlin/no/risc/utils/comparison/Comparison.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/Comparison.kt
@@ -390,6 +390,7 @@ fun compareActions5X(
                     ),
                 lastUpdated = changeForNonMandatorySimpleProperty(oldAction.lastUpdated, newAction.lastUpdated),
                 lastUpdatedBy = changeForNonMandatorySimpleProperty(oldAction.lastUpdatedBy, newAction.lastUpdatedBy),
+                comment = changeForNonMandatorySimpleProperty(oldAction.comment, newAction.comment),
             )
         },
     )

--- a/src/main/kotlin/no/risc/utils/comparison/ComparisonDTOs.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/ComparisonDTOs.kt
@@ -133,6 +133,7 @@ data class RiSc5XScenarioActionChange(
         OffsetDateTime?,
     >? = null,
     val lastUpdatedBy: SimpleTrackedProperty<String?>? = null,
+    val comment: SimpleTrackedProperty<String?>? = null,
 )
 
 /***************

--- a/src/main/resources/schemas/risc_schema_en_v5_2.json
+++ b/src/main/resources/schemas/risc_schema_en_v5_2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_1.json",
+  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_2.json",
   "title": "Risk Scorecard (RiSc)",
   "description": "Schema for risk scorecard",
   "type": "object",

--- a/src/main/resources/schemas/risc_schema_en_v5_3.json
+++ b/src/main/resources/schemas/risc_schema_en_v5_3.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_1.json",
+  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_3.json",
   "title": "Risk Scorecard (RiSc)",
   "description": "Schema for risk scorecard",
   "type": "object",
@@ -8,7 +8,7 @@
     "schemaVersion": {
       "description": "Schema version",
       "type": "string",
-      "default": "'5.2'"
+      "default": "'5.3'"
     },
     "title": {
       "description": "Title of the risk scorecard",
@@ -207,6 +207,9 @@
           "format": "date-time"
         },
         "lastUpdatedBy": {
+          "type": "string"
+        },
+        "comment": {
           "type": "string"
         }
       },


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion
](https://www.notion.so/bekks/Utforske-kommentarfelt-under-tiltak-for-utdype-rundt-status-p-tiltaket-35f6bd30854180deb1fdf8a47da10eee?source=copy_link)

⚠️ Kommer en frontend pr også

Introduces a new optional comment field on RiSc5XScenarioAction, allowing users to attach free-text comments to individual risk scenario actions.

  Changes

   - New schema version
    5.3 with comment property in the action definition
   - Model: Added "comment" to FlattenSerializer subKeys for correct serialization
   - Migration: Trivial
    5.2 → 5.3 migration (version bump only, comment defaults to null)
   - Comparison/diff: comment changes are now tracked in the diff output
   - Config: Bumped LATEST_SUPPORTED_SCHEMA_VERSION to 5.3

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
