### PR TITLE
feat: Add comment property to action

### DIFF
--- a/docs/schemaChangelog.md
+++ b/docs/schemaChangelog.md
@@ -1,5 +1,9 @@
 # Schema changelog
 
+## 5.4
+
+- Adds optional comment field to actions. 
+
 ## 5.3
 
 - Adds optional unencryptedMetadata.appliesTo field for unencrypted typed references covered by the scorecard, for

--- a/src/main/kotlin/no/risc/config/AppConstants.kt
+++ b/src/main/kotlin/no/risc/config/AppConstants.kt
@@ -1,5 +1,5 @@
 package no.risc.config
 
 object AppConstants {
-    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.3"
+    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.4"
 }

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -53,6 +53,7 @@ sealed interface RiSc {
                     RiScVersion.RiSc5XVersion.VERSION_5_1,
                     RiScVersion.RiSc5XVersion.VERSION_5_2,
                     RiScVersion.RiSc5XVersion.VERSION_5_3,
+                    RiScVersion.RiSc5XVersion.VERSION_5_4,
                     -> {
                         parseJSONToClass<RiSc5X>(content)
                     }
@@ -89,6 +90,9 @@ sealed interface RiScVersion {
 
         @SerialName("5.3")
         VERSION_5_3,
+
+        @SerialName("5.4")
+        VERSION_5_4,
         ;
 
         override fun asString(): String = serializer().descriptor.getElementName(ordinal)
@@ -194,7 +198,7 @@ data class RiSc5XScenario(
 private object RiSc5XScenarioActionSerializer : FlattenSerializer<RiSc5XScenarioAction>(
     serializer = RiSc5XScenarioAction.generatedSerializer(),
     flattenKey = "action",
-    subKeys = listOf("ID", "url", "status", "description", "lastUpdated", "lastUpdatedBy"),
+    subKeys = listOf("ID", "url", "status", "description", "lastUpdated", "lastUpdatedBy", "comment"),
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -210,6 +214,7 @@ data class RiSc5XScenarioAction(
     @Serializable(KNullableOffsetDateTimeSerializer::class)
     val lastUpdated: OffsetDateTime? = null,
     val lastUpdatedBy: String? = null,
+    val comment: String? = null,
 )
 
 /***************

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -719,9 +719,10 @@ fun migrateFrom52To53(
 fun migrateFrom53To54(
     riSc: RiSc5X,
     migrationStatus: MigrationStatus,
-): Pair<RiSc5X, MigrationStatus> = Pair(
-    riSc.copy(
-        schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
-    ),
-    migrationStatus,
-)
+): Pair<RiSc5X, MigrationStatus> =
+    Pair(
+        riSc.copy(
+            schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
+        ),
+        migrationStatus,
+    )

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -47,6 +47,7 @@ import no.risc.utils.comparison.MigrationChangedValue
  * - 5.0 -> 5.1 (add lastUpdatedBy field to action)
  * - 5.1 -> 5.2 (remove valuations)
  * - 5.2 -> 5.3 (add unencryptedMetadata.appliesTo)
+ * - 5.2 -> 5.4 (add comment field to action)
  *
  * @param riSc The RiSc to migrate.
  * @param lastPublished The last published version of the RisC to use for migration to 4.2
@@ -141,6 +142,7 @@ fun migrate(
  * - 5.0 -> 5.1 (add lastUpdatedBy field to action)
  * - 5.1 -> 5.2 (remove valuations)
  * - 5.2 -> 5.3 (add unencryptedMetadata.appliesTo)
+ * - 5.3 -> 5.4 (add comment field to action)
  *
  * @param riSc The RiSc to migrate
  * @param migrationStatus The migration status so far
@@ -183,6 +185,9 @@ private fun handleMigrate(
 
             riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_2 ->
                 migrateFrom52To53(riSc, migrationStatus)
+
+            riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_3 ->
+                migrateFrom53To54(riSc, migrationStatus)
 
             else -> {
                 if (riSc.schemaVersion != null) {
@@ -705,3 +710,18 @@ fun migrateFrom52To53(
         ),
         migrationStatus,
     )
+
+/**
+ * Migrate RiSc with changes from 5.3 to 5.4
+ *
+ * Adds optional comment field to actions (defaults to null, no data transformation needed).
+ */
+fun migrateFrom53To54(
+    riSc: RiSc5X,
+    migrationStatus: MigrationStatus,
+): Pair<RiSc5X, MigrationStatus> = Pair(
+    riSc.copy(
+        schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
+    ),
+    migrationStatus,
+)

--- a/src/main/kotlin/no/risc/utils/comparison/Comparison.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/Comparison.kt
@@ -395,6 +395,7 @@ fun compareActions5X(
                     ),
                 lastUpdated = changeForNonMandatorySimpleProperty(oldAction.lastUpdated, newAction.lastUpdated),
                 lastUpdatedBy = changeForNonMandatorySimpleProperty(oldAction.lastUpdatedBy, newAction.lastUpdatedBy),
+                comment = changeForNonMandatorySimpleProperty(oldAction.comment, newAction.comment),
             )
         },
     )

--- a/src/main/kotlin/no/risc/utils/comparison/ComparisonDTOs.kt
+++ b/src/main/kotlin/no/risc/utils/comparison/ComparisonDTOs.kt
@@ -134,6 +134,7 @@ data class RiSc5XScenarioActionChange(
         OffsetDateTime?,
     >? = null,
     val lastUpdatedBy: SimpleTrackedProperty<String?>? = null,
+    val comment: SimpleTrackedProperty<String?>? = null,
 )
 
 /***************

--- a/src/main/resources/schemas/risc_schema_en_v5_4.json
+++ b/src/main/resources/schemas/risc_schema_en_v5_4.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_2.json",
+  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_4.json",
   "title": "Risk Scorecard (RiSc)",
   "description": "Schema for risk scorecard",
   "type": "object",
@@ -8,7 +8,7 @@
     "schemaVersion": {
       "description": "Schema version",
       "type": "string",
-      "default": "'5.2'"
+      "default": "'5.4'"
     },
     "title": {
       "description": "Title of the risk scorecard",
@@ -17,6 +17,24 @@
     "scope": {
       "description": "The scope of the score card",
       "type": "string"
+    },
+    "unencryptedMetadata": {
+      "description": "Optional unencrypted metadata for the risk scorecard.",
+      "type": "object",
+      "properties": {
+        "appliesTo": {
+          "description": "Optional unencrypted typed target references that the risk scorecard applies to. Backstage catalog entity refs use the backstage: prefix.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9+.-]*:.+",
+            "maxLength": 512
+          },
+          "maxItems": 100,
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
     },
     "scenarios": {
       "type": "array",
@@ -61,7 +79,13 @@
           "anyOf": [
             {
               "type": "number",
-              "enum": [0.0025, 0.05, 1, 20, 400]
+              "enum": [
+                0.0025,
+                0.05,
+                1,
+                20,
+                400
+              ]
             },
             {
               "type": "number",
@@ -75,7 +99,13 @@
           "anyOf": [
             {
               "type": "number",
-              "enum": [8000, 160000, 3200000, 64000000, 1280000000]
+              "enum": [
+                8000,
+                160000,
+                3200000,
+                64000000,
+                1280000000
+              ]
             },
             {
               "type": "number",
@@ -187,7 +217,9 @@
         },
         "url": {
           "anyOf": [
-            {"$ref": "#/$defs/url"},
+            {
+              "$ref": "#/$defs/url"
+            },
             {
               "type": "string",
               "maxLength": 0
@@ -207,6 +239,9 @@
           "format": "date-time"
         },
         "lastUpdatedBy": {
+          "type": "string"
+        },
+        "comment": {
           "type": "string"
         }
       },


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion
](https://www.notion.so/bekks/Utforske-kommentarfelt-under-tiltak-for-utdype-rundt-status-p-tiltaket-35f6bd30854180deb1fdf8a47da10eee?source=copy_link)


Introduces a new optional comment field on RiSc5XScenarioAction, allowing users to attach free-text comments to individual risk scenario actions.

  Changes

   - New schema version
    5.4 with comment property in the action definition
   - Model: Added "comment" to FlattenSerializer subKeys for correct serialization
   - Migration: Trivial
    5.3 → 5.4 migration (version bump only, comment defaults to null)
   - Comparison/diff: comment changes are now tracked in the diff output
   - Config: Bumped LATEST_SUPPORTED_SCHEMA_VERSION to 5.4


---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
