### PR TITLE
Feat: hindre lagring av system-RoS i åpne repoer

### DIFF
--- a/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/risc/exception/GlobalExceptionHandler.kt
@@ -16,6 +16,7 @@ import no.risc.exception.exceptions.RiScNotValidOnFetchException
 import no.risc.exception.exceptions.RiScNotValidOnUpdateException
 import no.risc.exception.exceptions.SOPSDecryptionException
 import no.risc.exception.exceptions.SopsEncryptionException
+import no.risc.exception.exceptions.SystemRiScInPublicRepositoryException
 import no.risc.exception.exceptions.UpdatingRiScException
 import no.risc.risc.models.ContentStatus
 import no.risc.risc.models.DecryptionFailureDTO
@@ -234,6 +235,18 @@ internal class GlobalExceptionHandler {
         return ProcessRiScResultDTO(
             riScId = "",
             status = ProcessingStatus.InvalidGitHubAccessToken,
+            statusMessage = ex.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    @ExceptionHandler(SystemRiScInPublicRepositoryException::class)
+    fun handleSystemRiScInPublicRepositoryException(ex: SystemRiScInPublicRepositoryException): ProcessRiScResultDTO {
+        logger.error(ex.message, ex)
+        return ProcessRiScResultDTO(
+            riScId = "",
+            status = ProcessingStatus.SystemRiScNotAllowedInPublicRepository,
             statusMessage = ex.message,
         )
     }

--- a/src/main/kotlin/no/risc/exception/exceptions/SystemRiScInPublicRepositoryException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/SystemRiScInPublicRepositoryException.kt
@@ -1,0 +1,4 @@
+package no.risc.exception.exceptions
+
+class SystemRiScInPublicRepositoryException {
+}

--- a/src/main/kotlin/no/risc/exception/exceptions/SystemRiScInPublicRepositoryException.kt
+++ b/src/main/kotlin/no/risc/exception/exceptions/SystemRiScInPublicRepositoryException.kt
@@ -1,4 +1,6 @@
 package no.risc.exception.exceptions
 
-class SystemRiScInPublicRepositoryException {
-}
+class SystemRiScInPublicRepositoryException(
+    override val message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/src/main/kotlin/no/risc/github/GithubConnector.kt
+++ b/src/main/kotlin/no/risc/github/GithubConnector.kt
@@ -1272,6 +1272,7 @@ class GithubConnector(
         return RepositoryInfo(
             defaultBranch = repositoryDTO.defaultBranch,
             hasWriteAccess = repositoryDTO.permissions.push,
+            isPrivate = repositoryDTO.private,
         )
     }
 

--- a/src/main/kotlin/no/risc/github/models/GithubResponse.kt
+++ b/src/main/kotlin/no/risc/github/models/GithubResponse.kt
@@ -35,6 +35,7 @@ data class GithubRepositoryDTO(
     @SerialName("default_branch")
     val defaultBranch: String,
     val permissions: GithubRepositoryPermissions,
+    val private: Boolean = false,
 )
 
 /**

--- a/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
+++ b/src/main/kotlin/no/risc/infra/connector/models/AccessTokens.kt
@@ -8,6 +8,7 @@ data class AccessTokens(
 data class RepositoryInfo(
     val defaultBranch: String,
     val hasWriteAccess: Boolean,
+    val isPrivate: Boolean,
 )
 
 data class GCPAccessToken(

--- a/src/main/kotlin/no/risc/risc/RiScController.kt
+++ b/src/main/kotlin/no/risc/risc/RiScController.kt
@@ -98,13 +98,13 @@ class RiScController(
                         githubAccessToken = GithubAccessToken(gitHubAccessToken),
                     ),
                 content = newRiSc.toRiScWrapperObject(),
-                defaultBranch =
+                repositoryInfo =
                     githubConnector
                         .fetchRepositoryInfo(
                             repositoryOwner = repositoryOwner,
                             repositoryName = repositoryName,
                             gitHubAccessToken = gitHubAccessToken,
-                        ).defaultBranch,
+                        ),
                 generateDefault = generateDefault,
                 defaultRiScId = newRiSc.defaultRiScId,
             )
@@ -130,13 +130,13 @@ class RiScController(
                     gcpAccessToken = GCPAccessToken(gcpAccessToken),
                     githubAccessToken = GithubAccessToken(gitHubAccessToken),
                 ),
-            defaultBranch =
+            repositoryInfo =
                 githubConnector
                     .fetchRepositoryInfo(
                         repositoryOwner = repositoryOwner,
                         repositoryName = repositoryName,
                         gitHubAccessToken = gitHubAccessToken,
-                    ).defaultBranch,
+                    ),
         )
 
     @DeleteMapping("/{repositoryOwner}/{repositoryName}/{id}", produces = ["application/json"])

--- a/src/main/kotlin/no/risc/risc/RiScService.kt
+++ b/src/main/kotlin/no/risc/risc/RiScService.kt
@@ -11,6 +11,7 @@ import no.risc.exception.exceptions.DifferenceException
 import no.risc.exception.exceptions.RiScConflictException
 import no.risc.exception.exceptions.RiScNotValidOnUpdateException
 import no.risc.exception.exceptions.SOPSDecryptionException
+import no.risc.exception.exceptions.SystemRiScInPublicRepositoryException
 import no.risc.exception.exceptions.UpdatingRiScException
 import no.risc.github.GithubConnector
 import no.risc.github.RiScGithubMetadata
@@ -21,6 +22,7 @@ import no.risc.github.models.GithubPullRequestObject
 import no.risc.github.models.GithubStatus
 import no.risc.infra.connector.models.AccessTokens
 import no.risc.infra.connector.models.GCPAccessToken
+import no.risc.infra.connector.models.RepositoryInfo
 import no.risc.initRiSc.InitRiScServiceGitHubImpl
 import no.risc.risc.models.ContentStatus
 import no.risc.risc.models.CreateRiScResultDTO
@@ -34,6 +36,7 @@ import no.risc.risc.models.ProcessRiScResultDTO
 import no.risc.risc.models.ProcessingStatus
 import no.risc.risc.models.PublishRiScResultDTO
 import no.risc.risc.models.RiSc
+import no.risc.risc.models.RiSc5X
 import no.risc.risc.models.RiScContentResultDTO
 import no.risc.risc.models.RiScResult
 import no.risc.risc.models.RiScStatus
@@ -43,6 +46,7 @@ import no.risc.utils.comparison.compare
 import no.risc.utils.formatRiScFetchSummary
 import no.risc.utils.generateRiScId
 import no.risc.utils.migrate
+import no.risc.utils.parseJSONToClass
 import no.risc.utils.tryOrDefaultWithErrorLogging
 import no.risc.validation.JSONValidator
 import org.slf4j.Logger
@@ -375,7 +379,7 @@ class RiScService(
         riScId: String,
         content: RiScWrapperObject,
         accessTokens: AccessTokens,
-        defaultBranch: String,
+        repositoryInfo: RepositoryInfo,
     ): RiScResult =
         updateOrCreateRiSc(
             owner = owner,
@@ -384,7 +388,7 @@ class RiScService(
             content = content,
             sopsConfig = content.sopsConfig,
             accessTokens = accessTokens,
-            defaultBranch = defaultBranch,
+            repositoryInfo = repositoryInfo,
         )
 
     /**
@@ -404,7 +408,7 @@ class RiScService(
         repository: String,
         content: RiScWrapperObject,
         accessTokens: AccessTokens,
-        defaultBranch: String,
+        repositoryInfo: RepositoryInfo,
         generateDefault: Boolean,
         defaultRiScId: String?,
     ): CreateRiScResultDTO {
@@ -435,7 +439,7 @@ class RiScService(
                     content = riScContentWrapperObject,
                     sopsConfig = content.sopsConfig,
                     accessTokens = accessTokens,
-                    defaultBranch = defaultBranch,
+                    repositoryInfo = repositoryInfo,
                 )
 
             if (result.status != ProcessingStatus.UpdatedRiSc) {
@@ -452,6 +456,8 @@ class RiScService(
                 riScContent = riScContentWrapperObject.riSc,
                 sopsConfig = riScContentWrapperObject.sopsConfig,
             )
+        } catch (e: SystemRiScInPublicRepositoryException) {
+            throw e
         } catch (e: Exception) {
             throw CreatingRiScException(
                 message = "${e.message} for risk scorecard with id $uniqueRiScId",
@@ -479,7 +485,7 @@ class RiScService(
         content: RiScWrapperObject,
         sopsConfig: SopsConfig,
         accessTokens: AccessTokens,
-        defaultBranch: String,
+        repositoryInfo: RepositoryInfo,
     ): RiScResult {
         val validationStatus =
             JSONValidator.validateAgainstSchema(
@@ -497,6 +503,15 @@ class RiScService(
                 riScId = riScId,
                 validationError = validationError,
             )
+        }
+
+        if (!repositoryInfo.isPrivate && content.schemaVersion.startsWith("5")) {
+            val riSc = parseJSONToClass<RiSc5X>(content.riSc)
+            if (riSc.unencryptedMetadata?.appliesTo?.isNotEmpty() == true) {
+                throw SystemRiScInPublicRepositoryException(
+                    message = "System RiSc cannot be saved in a public repository",
+                )
+            }
         }
 
         val encryptedData: String =
@@ -554,7 +569,7 @@ class RiScService(
                     requiresNewApproval = content.isRequiresNewApproval,
                     gitHubAccessToken = accessTokens.githubAccessToken,
                     userInfo = content.userInfo,
-                    defaultBranch = defaultBranch,
+                    defaultBranch = repositoryInfo.defaultBranch,
                 )
 
             if (riScApprovalPRStatus.pullRequest != null) {

--- a/src/main/kotlin/no/risc/risc/models/DTOs.kt
+++ b/src/main/kotlin/no/risc/risc/models/DTOs.kt
@@ -189,6 +189,7 @@ enum class ProcessingStatus(
     FailedToCreateSops("Failed to create SOPS configuration"),
     FailedToFetchInitRiScFromGitHub("Failed to fetch initial RiSc from GitHub"),
     FailedToFetchInitRiScConfigFromGitHub("Failed to fetch initial RiSc config from GitHub"),
+    SystemRiScNotAllowedInPublicRepository("System RiSc is not allowed in public repository"),
 }
 
 @Serializable


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

System-RoSer inneholder et appliesTo-felt som lagres i ukryptert metadata.
  Dette feltet lister opp Backstage-komponentreferanser, som kan avsløre intern
  komponentstruktur for alle med lesetilgang til et offentlig repo — inkludert
  referanser til komponenter i private repoer.

  Hva denne PR-en gjør
  
  Blokkerer lagring av system-RoSer (RoSer med et ikke-tomt appliesTo-felt) i
  offentlige GitHub-repoer. Forsøk avvises med 400 Bad Request.

  Endringer

  GitHub API-integrasjon
  - Legger til private-felt i GithubRepositoryDTO for å hente repo-synlighet fra
   det eksisterende GET /repos/{owner}/{repo}-kallet
  - Legger til isPrivate i RepositoryInfo, mappet fra det nye feltet

  Controller
  - createNewRiSc og editRiSc sender nå hele RepositoryInfo-objektet til
  servicen i stedet for kun defaultBranch, og unngår dermed et ekstra GitHub
  API-kall  

  Service
  - updateRiSc, createRiSc og updateOrCreateRiSc tar imot RepositoryInfo i
  stedet for separate defaultBranch- og isPrivate-parametere
  - Valideringssjekk i updateOrCreateRiSc: hvis repoet er offentlig og RoS-en
  (schema 5.x) har et ikke-tomt appliesTo, kastes
  SystemRiScInPublicRepositoryException
  - SystemRiScInPublicRepositoryException re-throws eksplisitt i createRiSc for
  å forhindre at den svelges av den generelle catch-blokken

  Feilhåndtering
  - Ny SystemRiScInPublicRepositoryException
  - Ny ProcessingStatus.SystemRiScNotAllowedInPublicRepository
  - Mappet til 400 Bad Request i GlobalExceptionHandler

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
