### PR TITLE
Introduce schema version 5.5

### DIFF
--- a/docs/schemaChangelog.md
+++ b/docs/schemaChangelog.md
@@ -1,5 +1,10 @@
 # Schema changelog
 
+## 5.5
+
+- Adds threat actor "External supplier".
+- Adds vulnerabilities "Insufficient training", "Poor governance" and "Excessive privilege".
+
 ## 5.4
 
 - Adds optional comment field to actions. 

--- a/src/main/kotlin/no/risc/config/AppConstants.kt
+++ b/src/main/kotlin/no/risc/config/AppConstants.kt
@@ -1,5 +1,5 @@
 package no.risc.config
 
 object AppConstants {
-    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.4"
+    const val LATEST_SUPPORTED_SCHEMA_VERSION: String = "5.5"
 }

--- a/src/main/kotlin/no/risc/risc/models/RiSc.kt
+++ b/src/main/kotlin/no/risc/risc/models/RiSc.kt
@@ -54,6 +54,7 @@ sealed interface RiSc {
                     RiScVersion.RiSc5XVersion.VERSION_5_2,
                     RiScVersion.RiSc5XVersion.VERSION_5_3,
                     RiScVersion.RiSc5XVersion.VERSION_5_4,
+                    RiScVersion.RiSc5XVersion.VERSION_5_5,
                     -> {
                         parseJSONToClass<RiSc5X>(content)
                     }
@@ -93,6 +94,9 @@ sealed interface RiScVersion {
 
         @SerialName("5.4")
         VERSION_5_4,
+
+        @SerialName("5.5")
+        VERSION_5_5,
         ;
 
         override fun asString(): String = serializer().descriptor.getElementName(ordinal)
@@ -277,7 +281,17 @@ enum class RiScScenarioVulnerability {
     INFORMATION_LEAK,
 
     @SerialName("Excessive use")
-    EXCESSIVE_USE, ;
+    EXCESSIVE_USE,
+
+    @SerialName("Insufficient training")
+    INSUFFICIENT_TRAINING,
+
+    @SerialName("Poor governance")
+    POOR_GOVERNANCE,
+
+    @SerialName("Excessive privilege")
+    EXCESSIVE_PRIVILEGE,
+    ;
 
     override fun toString(): String = serializer().descriptor.getElementName(ordinal)
 }
@@ -498,6 +512,9 @@ enum class RiScScenarioThreatActor {
 
     @SerialName("Nation/government")
     NATION_OR_GOVERNMENT,
+
+    @SerialName("External supplier")
+    EXTERNAL_SUPPLIER,
 }
 
 @Serializable

--- a/src/main/kotlin/no/risc/utils/Migrations.kt
+++ b/src/main/kotlin/no/risc/utils/Migrations.kt
@@ -47,7 +47,8 @@ import no.risc.utils.comparison.MigrationChangedValue
  * - 5.0 -> 5.1 (add lastUpdatedBy field to action)
  * - 5.1 -> 5.2 (remove valuations)
  * - 5.2 -> 5.3 (add unencryptedMetadata.appliesTo)
- * - 5.2 -> 5.4 (add comment field to action)
+ * - 5.3 -> 5.4 (add comment field to action)
+ * - 5.4 -> 5.5 (add enum values for threat actors and vulnerabilities)
  *
  * @param riSc The RiSc to migrate.
  * @param lastPublished The last published version of the RisC to use for migration to 4.2
@@ -143,6 +144,7 @@ fun migrate(
  * - 5.1 -> 5.2 (remove valuations)
  * - 5.2 -> 5.3 (add unencryptedMetadata.appliesTo)
  * - 5.3 -> 5.4 (add comment field to action)
+ * - 5.4 -> 5.5 (add enum values for threat actors and vulnerabilities)
  *
  * @param riSc The RiSc to migrate
  * @param migrationStatus The migration status so far
@@ -188,6 +190,9 @@ private fun handleMigrate(
 
             riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_3 ->
                 migrateFrom53To54(riSc, migrationStatus)
+
+            riSc is RiSc5X && riSc.schemaVersion == RiScVersion.RiSc5XVersion.VERSION_5_4 ->
+                migrateFrom54To55(riSc, migrationStatus)
 
             else -> {
                 if (riSc.schemaVersion != null) {
@@ -723,6 +728,23 @@ fun migrateFrom53To54(
     Pair(
         riSc.copy(
             schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
+        ),
+        migrationStatus,
+    )
+
+/**
+ * Migrate RiSc with changes from 5.4 to 5.5
+ *
+ * Adds threat actor and vulnerability enum values in the schema only.
+ * Existing RiSc content only needs a schemaVersion bump.
+ */
+fun migrateFrom54To55(
+    riSc: RiSc5X,
+    migrationStatus: MigrationStatus,
+): Pair<RiSc5X, MigrationStatus> =
+    Pair(
+        riSc.copy(
+            schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_5,
         ),
         migrationStatus,
     )

--- a/src/main/resources/schemas/risc_schema_en_v5_5.json
+++ b/src/main/resources/schemas/risc_schema_en_v5_5.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kartverket.github.io/backstage-plugin-risk-scorecard-backend/risc_schema_en_v5_5.json",
+  "title": "Risk Scorecard (RiSc)",
+  "description": "Schema for risk scorecard",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "description": "Schema version",
+      "type": "string",
+      "default": "'5.5'"
+    },
+    "title": {
+      "description": "Title of the risk scorecard",
+      "type": "string"
+    },
+    "scope": {
+      "description": "The scope of the score card",
+      "type": "string"
+    },
+    "unencryptedMetadata": {
+      "description": "Optional unencrypted metadata for the risk scorecard.",
+      "type": "object",
+      "properties": {
+        "appliesTo": {
+          "description": "Optional unencrypted typed target references that the risk scorecard applies to. Backstage catalog entity refs use the backstage: prefix.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9+.-]*:.+",
+            "maxLength": 512
+          },
+          "maxItems": 100,
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "scenarios": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "scenario": {
+            "$ref": "#/$defs/scenario"
+          }
+        },
+        "required": [
+          "title",
+          "scenario"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "sops": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "title",
+    "scope",
+    "scenarios"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "risk": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "probability": {
+          "description": "Number of events/day",
+          "type": "number",
+          "anyOf": [
+            {
+              "type": "number",
+              "enum": [
+                0.0025,
+                0.05,
+                1,
+                20,
+                400
+              ]
+            },
+            {
+              "type": "number",
+              "minimum": 0
+            }
+          ]
+        },
+        "consequence": {
+          "description": "Monetary amount per day",
+          "type": "number",
+          "anyOf": [
+            {
+              "type": "number",
+              "enum": [
+                8000,
+                160000,
+                3200000,
+                64000000,
+                1280000000
+              ]
+            },
+            {
+              "type": "number",
+              "minimum": 0
+            }
+          ]
+        }
+      },
+      "required": [
+        "probability",
+        "consequence"
+      ],
+      "additionalProperties": false
+    },
+    "url": {
+      "type": "string",
+      "pattern": "^(?:(https?|s?ftp):\\/\\/)?(?:([\\w-]+)\\.)?([\\w-]+)\\.([\\w]+)\\/?(?:([^?#$]+))?(?:\\?([^#$]+))?(?:#(.*))?$"
+    },
+    "scenario": {
+      "type": "object",
+      "properties": {
+        "ID": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9]{5,}$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "$ref": "#/$defs/url"
+        },
+        "threatActors": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Script kiddie",
+              "Hacktivist",
+              "Reckless employee",
+              "Insider",
+              "Organised crime",
+              "Terrorist organisation",
+              "Nation/government",
+              "External supplier"
+            ]
+          }
+        },
+        "vulnerabilities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Flawed design",
+              "Misconfiguration",
+              "Dependency vulnerability",
+              "Unauthorized access",
+              "Unmonitored use",
+              "Input tampering",
+              "Information leak",
+              "Excessive use",
+              "Insufficient training",
+              "Poor governance",
+              "Excessive privilege"
+            ]
+          }
+        },
+        "risk": {
+          "$ref": "#/$defs/risk"
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "action": {
+                "$ref": "#/$defs/action"
+              }
+            },
+            "required": [
+              "title",
+              "action"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "remainingRisk": {
+          "$ref": "#/$defs/risk"
+        }
+      },
+      "required": [
+        "ID",
+        "description",
+        "threatActors",
+        "vulnerabilities",
+        "risk",
+        "actions",
+        "remainingRisk"
+      ],
+      "additionalProperties": false
+    },
+    "action": {
+      "type": "object",
+      "properties": {
+        "ID": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9]{5,}$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/url"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "OK",
+            "Not OK",
+            "Not relevant"
+          ]
+        },
+        "lastUpdated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastUpdatedBy": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "ID",
+        "description",
+        "status"
+      ],
+      "additionalProperties": false
+    }
+  }
+}
+

--- a/src/test/kotlin/no/risc/risc/models/RiScTests.kt
+++ b/src/test/kotlin/no/risc/risc/models/RiScTests.kt
@@ -388,6 +388,62 @@ class RiScTests {
         )
     }
 
+    @Test
+    fun `test RiSc5X parses and serializes new 5_5 enum values`() {
+        val riScJSONString =
+            """
+            {
+              "schemaVersion": "5.5",
+              "title": "Title",
+              "scope": "Scope",
+              "scenarios": [
+                {
+                  "title": "Scenario",
+                  "scenario": {
+                    "ID": "ABCDE",
+                    "description": "Description",
+                    "threatActors": ["External supplier"],
+                    "vulnerabilities": ["Insufficient training", "Poor governance", "Excessive privilege"],
+                    "risk": {"probability": 1, "consequence": 8000},
+                    "remainingRisk": {"probability": 1, "consequence": 8000},
+                    "actions": []
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val riSc = RiSc.fromContent(riScJSONString)
+        assertTrue(riSc is RiSc5X)
+
+        val scenario = (riSc as RiSc5X).scenarios.first()
+        assertEquals(RiScScenarioThreatActor.EXTERNAL_SUPPLIER, scenario.threatActors.first())
+        assertEquals(
+            listOf(
+                RiScScenarioVulnerability.INSUFFICIENT_TRAINING,
+                RiScScenarioVulnerability.POOR_GOVERNANCE,
+                RiScScenarioVulnerability.EXCESSIVE_PRIVILEGE,
+            ),
+            scenario.vulnerabilities,
+        )
+
+        val serialized = Json.parseToJsonElement(riSc.toJSON()).jsonObject
+        val serializedScenario =
+            serialized["scenarios"]!!
+                .jsonArray
+                .first()
+                .jsonObject["scenario"]!!
+                .jsonObject
+
+        assertEquals(
+            "External supplier",
+            serializedScenario["threatActors"]!!
+                .jsonArray
+                .first()
+                .jsonPrimitive.content,
+        )
+    }
+
     @ParameterizedTest
     @FieldSource("fromContentArguments")
     fun `test RiSc from content`(

--- a/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
+++ b/src/test/kotlin/no/risc/utils/MigrationFunctionTests.kt
@@ -626,6 +626,45 @@ class MigrationFunctionTests {
     }
 
     @Test
+    fun `test migrateFrom54To55`() {
+        val riSc =
+            RiSc5X(
+                schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
+                title = "Title",
+                scope = "Scope",
+                scenarios = emptyList(),
+            )
+        val migrationStatus =
+            MigrationStatus(
+                migrationChanges = false,
+                migrationRequiresNewApproval = false,
+                migrationVersions = MigrationVersions(fromVersion = null, toVersion = null),
+            )
+
+        val (migratedRiSc, migratedStatus) =
+            migrateFrom54To55(
+                riSc = riSc,
+                migrationStatus = migrationStatus,
+            )
+
+        assertEquals(
+            RiScVersion.RiSc5XVersion.VERSION_5_5,
+            migratedRiSc.schemaVersion,
+            "The schema version should be updated when migrating to version 5.5.",
+        )
+        assertEquals(
+            riSc,
+            migratedRiSc.copy(schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4),
+            "The only change to the RiSc when migrating to version 5.5 should be the schema version.",
+        )
+        assertEquals(
+            migrationStatus,
+            migratedStatus,
+            "Migrating to version 5.5 should not report content changes.",
+        )
+    }
+
+    @Test
     fun `test migrate`() {
         val resourceUrl = object {}.javaClass.classLoader.getResource("3.2.json")
 
@@ -710,6 +749,27 @@ class MigrationFunctionTests {
         assertThrows<IllegalStateException>("If an unsupported RiSc is provided, the migrate function should throw an exception") {
             migrate(riSc = UnknownRiSc(content = ""), lastPublished = null, endVersion = "4.2")
         }
+    }
+
+    @Test
+    fun `test migrate from 5_4 to 5_5 is schema version bump only`() {
+        val riSc54 =
+            RiSc5X(
+                schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4,
+                title = "Title",
+                scope = "Scope",
+                scenarios = emptyList(),
+            )
+        val (migratedRiSc, migratedStatus) =
+            migrate(
+                riSc = riSc54,
+                lastPublished = null,
+                endVersion = RiScVersion.RiSc5XVersion.VERSION_5_5,
+            )
+
+        assertEquals(RiScVersion.RiSc5XVersion.VERSION_5_5, migratedRiSc.schemaVersion)
+        assertEquals(riSc54, (migratedRiSc as RiSc5X).copy(schemaVersion = RiScVersion.RiSc5XVersion.VERSION_5_4))
+        assertEquals(false, migratedStatus.migrationChanges, "Migration 5.4 -> 5.5 should not report data changes.")
     }
 
     @Test

--- a/src/test/kotlin/no/risc/validation/JSONValidatorTests.kt
+++ b/src/test/kotlin/no/risc/validation/JSONValidatorTests.kt
@@ -283,5 +283,81 @@ class JSONValidatorTests {
         )
     }
 
+    @Test
+    fun `test retrieve version 5_5 schema accepts external supplier and new vulnerabilities`() {
+        val schema = JSONValidator.getSchemaOnUpdate(riScId = "abc", schemaVersion = "5.5")
+        val content =
+            """
+            {
+              "schemaVersion": "5.5",
+              "title": "Title",
+              "scope": "Scope",
+              "scenarios": [
+                {
+                  "title": "Scenario",
+                  "scenario": {
+                    "ID": "ABCDE",
+                    "description": "Description",
+                    "threatActors": ["External supplier"],
+                    "vulnerabilities": [
+                      "Insufficient training",
+                      "Poor governance",
+                      "Excessive privilege"
+                    ],
+                    "risk": {
+                      "probability": 1,
+                      "consequence": 8000
+                    },
+                    "actions": [],
+                    "remainingRisk": {
+                      "probability": 1,
+                      "consequence": 8000
+                    }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
+        assertTrue(output.isValid)
+    }
+
+    @Test
+    fun `test retrieve version 5_4 schema rejects external supplier`() {
+        val schema = JSONValidator.getSchemaOnUpdate(riScId = "abc", schemaVersion = "5.4")
+        val content =
+            """
+            {
+              "schemaVersion": "5.4",
+              "title": "Title",
+              "scope": "Scope",
+              "scenarios": [
+                {
+                  "title": "Scenario",
+                  "scenario": {
+                    "ID": "ABCDE",
+                    "description": "Description",
+                    "threatActors": ["External supplier"],
+                    "vulnerabilities": ["Flawed design"],
+                    "risk": {
+                      "probability": 1,
+                      "consequence": 8000
+                    },
+                    "actions": [],
+                    "remainingRisk": {
+                      "probability": 1,
+                      "consequence": 8000
+                    }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val output = JSONValidator.validateAgainstSchema(riScId = "abc", riScContent = content, schema = schema)
+        assertFalse(output.isValid)
+    }
+
     // må skrive en test her for å validere 4.2 opp mot de andre?
 }


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion](https://app.notion.com/p/bekks/Implementer-ny-schemaVersion-5-5-38b6bd30854180169546dbe08c589fa9?source=copy_link)

<!-- Beskriv kort hva som er endret og gjerne legg ved link til Notion oppgave Pro-tip: marker teksten over og lim inn lenken til oppgavekortet 😉. -->
<!-- PS: Legg gjerne lenken til PR'en i Notion kortet også :) -->

Introduserer ny schemaVersion 5.5 som introudserer følgende:

Threat actors:
- External supplier

Vulnerabilities
- Poor governance
- Insufficient training
- Excessive privilege

<!-- Legg til skjermbilder eller GIF-er som viser endringene visuelt. -->
<!-- Eventuelt linker til relevante ting (risc.yaml-fil, spesielle RoS'er i dev-miljøet) -->

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/blob/main/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).