### PR TITLE
Remove redundant BOM property overrides

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_25
 }
 
-extra["tomcat.version"] = "11.0.22" // Vulnerability in 11.0.20
-extra["jackson-bom.version"] = "3.1.4" // Vulnerability in 3.1.3
-extra["netty.version"] = "4.2.15.Final"
 extra["logback.version"] = "1.5.35"
 
 repositories {


### PR DESCRIPTION
# 📝 Beskrivelse

Lenke til oppgave i Notion

```
tomcat.version = 11.0.22 is redundant; Spring Boot 4.1.0 already pins Tomcat to 11.0.22.

netty.version = 4.2.15.Final is redundant; Spring Boot 4.1.0 already pins Netty to 4.2.15.Final.

jackson-bom.version = 3.1.4 is redundant; Spring Boot 4.1.0 already imports tools.jackson:jackson-bom:3.1.4
```

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn
- [ ] Det er brukt minst en conventional commit med passende prefix hvis denne PR'en skal lage en ny release
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
