### PR TITLE
Exclude Socat from being built in CI

### DIFF
--- a/.github/workflows/build-and-deploy-to-skip.yml
+++ b/.github/workflows/build-and-deploy-to-skip.yml
@@ -134,6 +134,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          target: production
           push: ${{ !github.event.pull_request.draft }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# 📝 Beskrivelse

Lenke til oppgave i Notion

Excludes Socat from being built in CI, by adding `target: production` under the `docker/build-push-action@v5` step. Socat is only required by the local Docker stage for frontend-backend relay, so production image builds are now isolated from repo.or.cz availability. Socat is required because we use a distroless Docker image.

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn
- [ ] Det er brukt minst en conventional commit med passende prefix hvis denne PR'en skal lage en ny release
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
